### PR TITLE
Fix aircrack_ng_pcap.m4

### DIFF
--- a/build/m4/aircrack_ng_pcap.m4
+++ b/build/m4/aircrack_ng_pcap.m4
@@ -59,7 +59,7 @@ AC_ARG_WITH(libpcap-lib,
 dnl
 dnl Search for headers
 dnl
-if test "${with_libpcap_includes+set}" != set; then
+if test "${with_libpcap_include+set}" != set; then
 	AC_MSG_CHECKING(pcap header directories)
 
 	found_pcap_dir=""

--- a/build/m4/aircrack_ng_pcap.m4
+++ b/build/m4/aircrack_ng_pcap.m4
@@ -43,7 +43,7 @@ AC_ARG_WITH(libpcap-include,
         [use PCAP includes in DIR, [default=auto]])
     ],[
     	if test -d "$withval" ; then
-    		CPPFLAGS="$CPPFLAGS -I $withval"
+    		CPPFLAGS="$CPPFLAGS -I$withval"
     	fi
     ])
 
@@ -52,7 +52,7 @@ AC_ARG_WITH(libpcap-lib,
         [use PCAP libraries in DIR, [default=auto]])
     ],[
     	if test -d "$withval" ; then
-    		LDFLAGS="$LDFLAGS -L $withval"
+    		LDFLAGS="$LDFLAGS -L$withval"
     	fi
     ])
 


### PR DESCRIPTION
This fixes two problems with aircrack_ng_pcap.m4, which appear when using the configure arguments `--with-libpcap-include=/somewhere/include` and `--with-libpcap-lib=/somewhere/lib`.

1. `libtool:   error: require no space between '-L' and '/somewhere/lib'`
2. `checking pcap header directories... /usr/include/pcap`
