### PR TITLE
autotools: The flag --without-opt should skip stack protector flags.

### DIFF
--- a/build/m4/aircrack_ng_compiler.m4
+++ b/build/m4/aircrack_ng_compiler.m4
@@ -108,19 +108,23 @@ case "$ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor" in
             CYGWIN*|MSYS*|cygwin*|msys*)
                 ;;
             *)
-                AS_IF([test "x$gcc_over49" = "xno"], [
-                    AS_IF([test "x$gcc_over41" = "xyes"], [
-                        AX_CHECK_COMPILE_FLAG([-fstack-protector], [
-                            AX_APPEND_FLAG(-fstack-protector, [opt_[]_AC_LANG_ABBREV[]flags])
-                        ])
-                    ], [])
-                ], [])
+                case $with_opt in
+                    yes | "")
+                        AS_IF([test "x$gcc_over49" = "xno"], [
+                            AS_IF([test "x$gcc_over41" = "xyes"], [
+                                AX_CHECK_COMPILE_FLAG([-fstack-protector], [
+                                    AX_APPEND_FLAG(-fstack-protector, [opt_[]_AC_LANG_ABBREV[]flags])
+                                ])
+                            ], [])
+                        ], [])
 
-                AS_IF([test "x$gcc_over49" = "xyes"], [
-                    AX_CHECK_COMPILE_FLAG([-fstack-protector-strong], [
-                        AX_APPEND_FLAG(-fstack-protector-strong, [opt_[]_AC_LANG_ABBREV[]flags])
-                    ])
-                ], [])
+                        AS_IF([test "x$gcc_over49" = "xyes"], [
+                            AX_CHECK_COMPILE_FLAG([-fstack-protector-strong], [
+                                AX_APPEND_FLAG(-fstack-protector-strong, [opt_[]_AC_LANG_ABBREV[]flags])
+                            ])
+                        ], [])
+                        ;;
+                esac
                 ;;
         esac
         ;;


### PR DESCRIPTION
Fix for #1862 