### PR TITLE
Airodump-ng: Automatically colorize airodump.

### DIFF
--- a/src/aircrack-util/console.h
+++ b/src/aircrack-util/console.h
@@ -82,6 +82,8 @@
 #define KEY_n 0x6E
 #define KEY_r 0x72
 #define KEY_s 0x73
+#define KEY_o 0x6F	//color on
+#define KEY_p 0x70	//color off
 
 /// Changes the styling, foreground, and background
 /// character color, as shown in the user's terminal


### PR DESCRIPTION
I've patched airodump so that upon a key press it automatically adds colors only to the APs that have associated clients. Also clients that are not associated are greyed out. This makes it much easier to see who's-connected-to-who and who-is-probing-for-who.

Press o to turn the color on, and p to turn it off.