### PR TITLE
Autoconf: Added NEON intrinsic support.

### DIFF
--- a/build/m4/aircrack_ng_simd.m4
+++ b/build/m4/aircrack_ng_simd.m4
@@ -95,6 +95,13 @@ then
         AX_APPEND_FLAG(-mfpu=neon, [arm_neon_[]_AC_LANG_ABBREV[]flags])
         AC_SUBST(arm_neon_[]_AC_LANG_ABBREV[]flags)
     ])
+
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#if !defined(__ARM_NEON) && !defined(__ARM_NEON__)
+#error macro not defined
+#endif
+    ]])], [NEON_FOUND=1], [NEON_FOUND=0])
+    AC_SUBST(NEON_FOUND)
 fi
 
 if test $IS_PPC -eq 1
@@ -185,6 +192,7 @@ fi
 AM_CONDITIONAL([X86], [test "$IS_X86" = 1])
 AM_CONDITIONAL([ARM], [test "$IS_ARM" = 1])
 AM_CONDITIONAL([PPC], [test "$IS_PPC" = 1])
+AM_CONDITIONAL([NEON], [test "$NEON_FOUND" = 1])
 ])
 
 AC_DEFUN([AIRCRACK_NG_SIMD_C], [

--- a/build/m4/aircrack_ng_simd.m4
+++ b/build/m4/aircrack_ng_simd.m4
@@ -96,12 +96,20 @@ then
         AC_SUBST(arm_neon_[]_AC_LANG_ABBREV[]flags)
     ])
 
-    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    AS_VAR_PUSHDEF([CACHEVAR], [ax_cv_neon_[]_AC_LANG_ABBREV[]flags])
+    AC_CACHE_CHECK([whether _AC_LANG compiler supports NEON instructions], CACHEVAR, [
+        ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+        _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS -mfpu=neon"
+        AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 #if !defined(__ARM_NEON) && !defined(__ARM_NEON__) && !defined(__aarch64) && !defined(__aarch64__)
 #error macro not defined
 #endif
-    ]])], [NEON_FOUND=1], [NEON_FOUND=0])
-    AC_SUBST(NEON_FOUND)
+        ]])], [AS_VAR_SET(CACHEVAR,[yes])], [AS_VAR_SET(CACHEVAR,[no])])
+        _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags
+    ])
+    AS_IF([test x"AS_VAR_GET(CACHEVAR)" = xyes],
+        [NEON_FOUND=1], [NEON_FOUND=0])
+    AS_VAR_POPDEF([CACHEVAR])
 fi
 
 if test $IS_PPC -eq 1

--- a/build/m4/aircrack_ng_simd.m4
+++ b/build/m4/aircrack_ng_simd.m4
@@ -97,7 +97,7 @@ then
     ])
 
     AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#if !defined(__ARM_NEON) && !defined(__ARM_NEON__)
+#if !defined(__ARM_NEON) && !defined(__ARM_NEON__) && !defined(__aarch64) && !defined(__aarch64__)
 #error macro not defined
 #endif
     ]])], [NEON_FOUND=1], [NEON_FOUND=0])

--- a/build/m4/aircrack_ng_simd.m4
+++ b/build/m4/aircrack_ng_simd.m4
@@ -99,7 +99,7 @@ then
     AS_VAR_PUSHDEF([CACHEVAR], [ax_cv_neon_[]_AC_LANG_ABBREV[]flags])
     AC_CACHE_CHECK([whether _AC_LANG compiler supports NEON instructions], CACHEVAR, [
         ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
-        _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS -mfpu=neon"
+        _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $arm_neon_[]_AC_LANG_ABBREV[]flags"
         AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 #if !defined(__ARM_NEON) && !defined(__ARM_NEON__) && !defined(__aarch64) && !defined(__aarch64__)
 #error macro not defined

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -116,8 +116,10 @@ endif
 pkglibexec_PROGRAMS = aircrack-ng--generic
 
 if ARM
+if NEON
 pkglibexec_PROGRAMS += aircrack-ng--neon \
                        aircrack-ng--asimd
+endif
 endif
 
 if PPC


### PR DESCRIPTION
Perform NEON intrinsic support using Autoconf, instead of failing to build on older ARM processors without NEON features.