### PR TITLE
Removed redundant 'break'

### DIFF
--- a/src/osdep/radiotap/parse.c
+++ b/src/osdep/radiotap/parse.c
@@ -67,7 +67,6 @@ static void print_radiotap_namespace(struct ieee80211_radiotap_iterator *iter)
 	case IEEE80211_RADIOTAP_RTS_RETRIES:
 	case IEEE80211_RADIOTAP_DATA_RETRIES:
 		break;
-		break;
 	default:
 		printf("\tBOGUS DATA\n");
 		break;


### PR DESCRIPTION
Removed redundant 'break'