### PR TITLE
Fix compilation without getauxval

### DIFF
--- a/src/trampoline_arm.c
+++ b/src/trampoline_arm.c
@@ -17,8 +17,10 @@
  */
 
 #if defined(__arm__) || defined(__aarch64__)
+#ifdef HAS_AUXV
 #include <sys/auxv.h>
 #include <asm/hwcap.h>
+#endif
 #else
 #error "The wrong CPU architecture file has been included."
 #endif
@@ -39,6 +41,7 @@ int
 simd_get_supported_features (void)
 {
   int result = 0;
+#ifdef HAS_AUXV
   long hwcaps = getauxval (AT_HWCAP);
 
 #if defined(HWCAP_ASIMD)
@@ -53,6 +56,7 @@ simd_get_supported_features (void)
   {
     result |= SIMD_SUPPORTS_NEON;
   }
+#endif
 #endif
 
   return (result);

--- a/src/trampoline_ppc.c
+++ b/src/trampoline_ppc.c
@@ -17,8 +17,10 @@
  */
 
 #if defined(__ppc__) || defined(__PPC__)
+#ifdef HAS_AUXV
 #include <sys/auxv.h>
 #include <bits/hwcap.h>
+#endif
 #else
 #error "The wrong CPU architecture file has been included."
 #endif
@@ -39,6 +41,7 @@ int
 simd_get_supported_features (void)
 {
   int result = 0;
+#ifdef HAS_AUXV
   long hwcaps = getauxval (AT_HWCAP2);
 
 #if defined(PPC_FEATURE2_ARCH_2_07)
@@ -46,6 +49,7 @@ simd_get_supported_features (void)
   {
     result |= SIMD_SUPPORTS_POWER8;
   }
+#endif
 #endif
 
   return (result);


### PR DESCRIPTION
Protect getauxval call and sys/auxv.h include by #ifdef HAS_AUXV in
trampoline_arm.c and trampoline_ppc.c.
Indeed, auxv is not available on some toolchains such as uclibc

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>