### PR TITLE
Aircrack-ng: Create/Restore session

### DIFF
--- a/manpages/aircrack-ng.1
+++ b/manpages/aircrack-ng.1
@@ -112,6 +112,12 @@ Specify maximum number of IVs to use.
 .I -w <words>
 Path to a dictionary file for wpa cracking. Separate filenames with comma when using multiple dictionaries. Specify "-" to use stdin. Here is a list of wordlists: https://www.aircrack-ng.org/doku.php?id=faq#where_can_i_find_good_wordlists
 In order to use a dictionary with hexadecimal values, prefix the dictionary with "h:". Each byte in each key must be separated by ':'. When using with WEP, key length should be specified using -n.
+.TP
+.I -N <file> or --new-session <file>
+Create a new cracking session. It allows to interrupt cracking session and restart at a later time (using -R or --restore-session). Status files are saved every 5 minutes. It does not overwrite existing session file.
+.TP
+.I -R <file> or --restore-session <file>
+Restore and continue a previously saved cracking session. This parameter is to be used alone, no other parameter should be specified when starting aircrack-ng (all the required information is in the session file).
 .PP
 .TP
 .B WPA-PSK options:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,11 +83,11 @@ SRC_AV		= airventriloquist-ng.c
 
 SRC_SSE_COMMON	= memory.c wpapsk.c
 LIBAC_CFLAGS = -DOLD_SSE_CORE=1
-SRC_ACLIB	= cpuid.c crypto.c common.c $(SSEC_INT) uniqueiv.c $(ASM_AC) verifyssid.c
+SRC_ACLIB	= cpuid.c crypto.c common.c $(SSEC_INT) uniqueiv.c $(ASM_AC) verifyssid.c session.c
 LIBAC	= libaclib.la
 LIBAC_LIBS = libaclib.la
 
-AC_COMMON = cpuid.c crypto.c common.c $(SRC_SSE_COMMON) uniqueiv.c $(ASM_AC) verifyssid.c
+AC_COMMON = cpuid.c crypto.c common.c $(SRC_SSE_COMMON) uniqueiv.c $(ASM_AC) verifyssid.c session.c
 
 if LIBGCRYPT
 SRC_AC		+= sha1-git.c
@@ -408,7 +408,9 @@ EXTRA_DIST = wpaclean.c \
              cowpatty.c \
              cowpatty.h \
              verifyssid.c \
-             verifyssid.h 
+             verifyssid.h \
+             session.c \
+             session.h
 
 
 @CODE_COVERAGE_RULES@

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -5888,7 +5888,7 @@ int main( int argc, char *argv[] )
 
 	progname = getVersion("Aircrack-ng", _MAJ, _MIN, _SUB_MIN, _REVISION, _BETA, _RC);
 
-	if( argc - optind < 1 )
+	if ((cracking_session && cracking_session->argc - optind < 1) || ( !cracking_session && argc - optind < 1 ))
 	{
 		if(nbarg == 1)
 		{

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -5962,6 +5962,8 @@ usage:
                 fprintf(stderr, "Failed setting position in wordlist from restore session.\n");
                 clean_exit(EXIT_FAILURE);
             }
+            
+            // Set amount of keys tried -> Done later
         } else if( ! opt.essid_set && ! opt.bssid_set) {
 			/* ask the user which network is to be cracked */
 
@@ -6178,7 +6180,8 @@ __start:
 	/* launch the attack */
 
 	pthread_mutex_lock(&mx_nb);
-	nb_tried = 0;
+    // Set the amount of keys tried
+	nb_tried = (cracking_session && restore_session) ? cracking_session->nb_keys_tried : 0;
 	nb_kprev = 0;
 	pthread_mutex_unlock(&mx_nb);
 

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -446,7 +446,7 @@ void clean_exit(int ret)
 
     if (cracking_session) {
         // TODO: Delete file when cracking fails
-        if (opt.dictfinish || wepkey_crack_success || wpa_wordlists_done) {
+        if (opt.dictfinish || wepkey_crack_success || wpa_wordlists_done || nb_tried == opt.wordcount) {
             delete_session_file(cracking_session);
         }
         free_struct_session(cracking_session);

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -5799,7 +5799,7 @@ int main( int argc, char *argv[] )
 	}
 
     // Cracking session is only for when one or more wordlists are used or stdin is used
-    if ((opt.dict == NULL || no_stdin) && cracking_session) {
+    if ((opt.dict == NULL || opt.no_stdin) && cracking_session) {
         fprintf(stderr, "Cannot save/restore cracking session when there is no wordlist.\n");
         goto usage;
     }

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -444,7 +444,7 @@ void clean_exit(int ret)
 	}
 
     if (cracking_session) {
-        free_struct_session(cracking_session, (ret == SUCCESS || ret == EXIT_SUCCESS || ret == 0));
+        free_struct_session(cracking_session);
         cracking_session = NULL;    
     }
 

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -6028,7 +6028,7 @@ usage:
             // Copy BSSID to the cracking session and save it
             if (cracking_session) {
                 memcpy(cracking_session->bssid, ap_cur->bssid, 6);
-                save_session_to_file(cracking_session, 0);
+                save_session_to_file(cracking_session, 0, 0);
             }
 
 			/* Disable PTW if dictionary used in WEP */

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -443,9 +443,10 @@ void clean_exit(int ret)
 		progname = NULL;
 	}
 
-    // TODO: Delete session if it is a success
-    free_struct_session(cracking_session);
-    cracking_session = NULL;
+    if (cracking_session) {
+        free_struct_session(cracking_session, (ret == SUCCESS || ret == EXIT_SUCCESS || ret == 0));
+        cracking_session = NULL;    
+    }
 
 	child_pid=fork();
 

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -5174,6 +5174,7 @@ int crack_wep_dict()
 		if(check_wep_key(wep.key, opt.keylen, 0) == SUCCESS)
 		{
 			free(key);
+			wepkey_crack_success = 1;
 			return( SUCCESS );
 		}
 	}

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -5089,10 +5089,16 @@ int next_key( char **key, int keysize )
 	return( SUCCESS );
 }
 
-int set_dicts(char* optargs)
+int set_dicts(const char* args)
 {
 	int len;
+	char * optargs = strdup(args);
 	char *optarg;
+
+	if (optargs == NULL) {
+		perror("Failed to allocate memory for arguments");
+		return( FAILURE );
+	}
 
 	opt.dictfinish = opt.totaldicts = opt.nbdict = 0;
 
@@ -5105,6 +5111,7 @@ int set_dicts(char* optargs)
 		}
 
 		if (!(opt.dicts[opt.nbdict] = strdup(optarg))) {
+			free(optargs);
 			perror("Failed to allocate memory for dictionary");
 			return( FAILURE );
 		}
@@ -5112,6 +5119,7 @@ int set_dicts(char* optargs)
 		opt.nbdict++;
 		opt.totaldicts++;
 	}
+	free(optargs);
 
 	for (len = opt.nbdict; len < MAX_DICTS; len++)
 		opt.dicts[len] = NULL;

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -5958,7 +5958,7 @@ usage:
             }
 
             // Move into position in the wordlist
-            if (fseeko64(opt.dict, cracking_session->pos, SEEK_SET) != 0 || ftello64(opt.dict) != cracking_session->pos) {
+            if (fseeko(opt.dict, cracking_session->pos, SEEK_SET) != 0 || ftello(opt.dict) != cracking_session->pos) {
                 fprintf(stderr, "Failed setting position in wordlist from restore session.\n");
                 clean_exit(EXIT_FAILURE);
             }

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -445,6 +445,7 @@ void clean_exit(int ret)
 	}
 
     if (cracking_session) {
+        // TODO: Delete file when cracking fails
         if (opt.dictfinish || wepkey_crack_success || wpa_wordlists_done) {
             delete_session_file(cracking_session);
         }
@@ -5842,10 +5843,12 @@ int main( int argc, char *argv[] )
 		goto __start;
 	}
 
-    // Cracking session is only for when one or more wordlists are used or stdin is used
-    if ((opt.dict == NULL || opt.no_stdin) && cracking_session) {
-        fprintf(stderr, "Cannot save/restore cracking session when there is no wordlist.\n");
-        goto usage;
+    // Cracking session is only for when one or more wordlists are used.
+    // Airolib-ng not supported and stdin not allowed.
+    if ((opt.dict == NULL || opt.no_stdin || db) && cracking_session) {
+        fprintf(stderr, "Cannot save/restore cracking session when there is no wordlist,"
+                        " when using stdin or when using airolib-ng database.");
+        goto exit_main;
     }
 
 	if( nbarg - optind < 1 )

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -447,10 +447,9 @@ void clean_exit(int ret)
     if (cracking_session) {
         // TODO: Delete file when cracking fails
         if (opt.dictfinish || wepkey_crack_success || wpa_wordlists_done || nb_tried == opt.wordcount) {
-            delete_session_file(cracking_session);
+            ac_session_destroy(cracking_session);
         }
-        free_struct_session(cracking_session);
-        cracking_session = NULL;    
+        ac_session_free(&cracking_session);
     }
 
 	child_pid=fork();
@@ -3026,7 +3025,7 @@ void save_cracking_session()
     // Update amount of keys tried and save it
     if (wordlist) {
         pthread_mutex_lock( &mx_ses );
-        save_session_to_file(cracking_session, nb_tried);
+        ac_session_save(cracking_session, nb_tried);
         pthread_mutex_unlock( &mx_ses );        
     }
 }
@@ -5362,7 +5361,7 @@ int main( int argc, char *argv[] )
 
     // Check if we are restoring from a session
     if (nbarg == 3 && (strcmp(argv[1], "--restore-session") == 0 || strcmp(argv[1], "-R") == 0)) {
-        cracking_session = load_session_file(argv[2]);
+        cracking_session = ac_session_load(argv[2]);
         if (cracking_session == NULL) {
             fprintf(stderr, "Failed loading session file: %s\n", argv[2]);
             return EXIT_FAILURE;
@@ -5411,7 +5410,7 @@ int main( int argc, char *argv[] )
                 // New session
                 if (cracking_session == NULL) {
                     // Ignore if there is a cracking session (which means it was loaded from it)
-                    cracking_session = new_struct_session(nbarg, argv, optarg);
+                    cracking_session = ac_session_from_argv(nbarg, argv, optarg);
                     if (cracking_session == NULL) {
                         return EXIT_FAILURE;
                     }

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -5938,9 +5938,21 @@ usage:
                 clean_exit(EXIT_FAILURE);
             }
 
+            // Set BSSID
             memcpy( opt.bssid, ap_cur->bssid,  6 );
             opt.bssid_set = 1;
-            
+
+            // Set wordlist
+            if (next_dict(cracking_session->wordlist_id)) {
+                fprintf(stderr, "Failed setting wordlist ID from restore session.\n");
+                clean_exit(EXIT_FAILURE);
+            }
+
+            // Move into position in the wordlist
+            if (fseeko64(opt.dict, cracking_session->pos, SEEK_SET) != 0 || ftello64(opt.dict) != cracking_session->pos) {
+                fprintf(stderr, "Failed setting position in wordlist from restore session.\n");
+                clean_exit(EXIT_FAILURE);
+            }
         } else if( ! opt.essid_set && ! opt.bssid_set) {
 			/* ask the user which network is to be cracked */
 
@@ -6025,10 +6037,9 @@ usage:
 			memcpy( opt.bssid, ap_cur->bssid,  6 );
 			opt.bssid_set = 1;
 
-            // Copy BSSID to the cracking session and save it
-            if (cracking_session) {
+            // Copy BSSID to the cracking session
+            if (cracking_session && opt.dict != NULL) {
                 memcpy(cracking_session->bssid, ap_cur->bssid, 6);
-                save_session_to_file(cracking_session, 0, 0);
             }
 
 			/* Disable PTW if dictionary used in WEP */

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -5798,6 +5798,12 @@ int main( int argc, char *argv[] )
 		goto __start;
 	}
 
+    // Cracking session is only for when one or more wordlists are used or stdin is used
+    if ((opt.dict == NULL || no_stdin) && cracking_session) {
+        fprintf(stderr, "Cannot save/restore cracking session when there is no wordlist.\n");
+        goto usage;
+    }
+
 	if( nbarg - optind < 1 )
 	{
 		if(nbarg == 1)

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -444,6 +444,9 @@ void clean_exit(int ret)
 	}
 
     if (cracking_session) {
+        if (opt.dictfinish || wepkey_crack_success || wpa_wordlists_done) {
+            delete_session_file(cracking_session);
+        }
         free_struct_session(cracking_session);
         cracking_session = NULL;    
     }
@@ -6492,6 +6495,7 @@ __start:
 						sqlite3_free(zErrMsg);
 					}
 					if (waited != 0) printf("\n\n");
+					wpa_wordlists_done = 1;
 					break;
 				}
 			}

--- a/src/common.c
+++ b/src/common.c
@@ -599,6 +599,14 @@ int hexToInt(char s[], int len)
 	return value;
 }
 
+void rtrim(char * line)
+{
+    if (line && strlen(line) > 0) {
+        if (line[strlen(line) - 1] == '\n') line[strlen(line) - 1] = 0;
+        if (line[strlen(line) - 1] == '\r') line[strlen(line) - 1] = 0;
+    }
+}
+
 char * get_current_working_directory()
 {
     char * ret = NULL;

--- a/src/common.c
+++ b/src/common.c
@@ -41,6 +41,8 @@
 #include <dirent.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <limits.h>
+#include <errno.h>
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 #include <sys/sysctl.h>
 #include <sys/user.h>
@@ -595,4 +597,28 @@ int hexToInt(char s[], int len)
 
 
 	return value;
+}
+
+char * get_current_working_directory()
+{
+    char * ret = NULL;
+    char * wd_realloc = NULL;
+    size_t wd_size = 0;
+
+    do {
+        wd_size += PATH_MAX;
+        char * wd_realloc = (char *)realloc(ret, wd_size);
+        if (wd_realloc == NULL) {
+            if (ret) free(ret);
+            return NULL;
+        }
+        ret = wd_realloc;
+        wd_realloc = getcwd(ret, wd_size);
+        if (wd_realloc == NULL && errno != ERANGE) {
+            if (ret) free(ret);
+            return NULL;
+        }
+    } while (wd_realloc == NULL && errno == ERANGE);
+    
+    return ret;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -85,5 +85,6 @@ int64_t ftello64(FILE * fp);
 
 void calctime(time_t t, float calc);
 char * get_current_working_directory();
+void rtrim(char * line);
 
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -84,5 +84,6 @@ int64_t ftello64(FILE * fp);
 #endif
 
 void calctime(time_t t, float calc);
+char * get_current_working_directory();
 
 #endif

--- a/src/session.c
+++ b/src/session.c
@@ -81,7 +81,7 @@ void free_struct_session(struct session * s)
  * Line 1: Working directory
  * Line 2: BSSID
  * Line 3: Wordlist ID followed by a space then position in file
- * Line 4: Amount of arguments (indicated how many lines will follow this one)
+ * Line 4: Amount of arguments (indicates how many lines will follow this one)
  * 
  * Notes:
  * - Any line starting with # is ignored

--- a/src/session.c
+++ b/src/session.c
@@ -344,27 +344,23 @@ struct session * ac_session_from_argv(const int argc, char ** argv, const char *
 
     // Get working directory and copy filename
     ret->working_dir = get_current_working_directory();
-    if (ret->working_dir == NULL) {
-        ac_session_free(&ret);
-        return NULL;
-    }
 
     // Copy filename
     ret->filename = strdup(filename);
-    if (ret->filename == NULL) {
-        ac_session_free(&ret);
-        return NULL;
-    }
 
     // Copy argc and argv, except the 2 specifying session filename location
     ret->argv = (char **)calloc(argc - AMOUNT_ARGUMENTS_IGNORE, sizeof(char *));
-    if (ret->argv == NULL) {
+    
+    // Check values are properly set
+    if (ret->filename == NULL || ret->working_dir == NULL || ret->argv == NULL) {
         ac_session_free(&ret);
         return NULL;
     }
+    
+    // Copy all the arguments
     for (int i = 0; i < argc; ++i) {
         if (strcmp(argv[i], filename) == 0) {
-            // Found the filename, now remove the previously copied argument
+            // Found the session filename, now remove the previously copied argument
             ret->argc--;
             free(ret->argv[ret->argc]);
             ret->argv[ret->argc] = NULL;

--- a/src/session.c
+++ b/src/session.c
@@ -40,9 +40,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include <limits.h>
 #include <inttypes.h>
-#include <errno.h>
+
+#include "common.h"
 
 int ac_session_destroy(struct session * s)
 {
@@ -298,22 +298,11 @@ struct session * ac_session_from_argv(const int argc, char ** argv, const char *
     ac_session_init(ret);
 
     // Get working directory and copy filename
-    size_t wd_size = 0;
-    char * wd_ret;
-    do {
-        wd_size += PATH_MAX;
-        char * wd_realloc = (char *)realloc(ret->working_dir, wd_size);
-        if (wd_realloc == NULL) {
-            ac_session_free(&ret);
-            return NULL;
-        }
-        ret->working_dir = wd_realloc;
-        wd_ret = getcwd(ret->working_dir, wd_size);
-        if (wd_ret == NULL && errno != ERANGE) {
-            ac_session_free(&ret);
-            return NULL;
-        }
-    } while (wd_ret == NULL && errno == ERANGE);
+    ret->working_dir = get_current_working_directory();
+    if (ret->working_dir == NULL) {
+        ac_session_free(&ret);
+        return NULL;
+    }
 
     // Copy filename
     ret->filename = strdup(filename);

--- a/src/session.c
+++ b/src/session.c
@@ -65,7 +65,18 @@ void free_struct_session(struct session * s)
         return;
     }
     
-    if (s->filename) free(s->filename);
+    
+    if (s->filename) {
+        
+        // Delete 0 byte file
+        struct stat scs;
+        memset(&scs, 0, sizeof(struct stat));
+        if (stat(s->filename, &scs) == 0 && scs.st_size == 0) {
+            delete_session_file(s);
+        }
+        
+        free(s->filename);
+    }
     if (s->argv) {
         for (int i = 0; i < s->argc; ++i) {
             free(s->argv[i]);

--- a/src/session.c
+++ b/src/session.c
@@ -163,6 +163,14 @@ struct session * load_session_file(const char * filename)
             }
             case 1: // BSSID
             {
+                // Check length
+                if (strlen(line) != 17) {
+                    free(line);
+                    fclose(f);
+                    free_struct_session(ret);
+                    return NULL;
+                }
+
                 // Parse BSSID
                 unsigned int bssid[6];
                 int count = sscanf(line, "%02X:%02X:%02X:%02X:%02X:%02X", &bssid[0], &bssid[1],

--- a/src/session.c
+++ b/src/session.c
@@ -76,6 +76,19 @@ void free_struct_session(struct session * s)
 }
 
 
+/*
+ * File format:
+ * Line 1: Working directory
+ * Line 2: BSSID
+ * Line 3: Wordlist ID followed by a space then position in file
+ * Line 4: Amount of arguments (indicated how many lines will follow this one)
+ * 
+ * Notes:
+ * - Any line starting with # is ignored
+ * - First 4 lines CANNOT be empty
+ * - Lines are trimmed of any possible \r and \n at the end
+ */
+
 #define SESSION_ARGUMENTS_LINE 4
 struct session * load_session_file(const char * filename)
 {

--- a/src/session.c
+++ b/src/session.c
@@ -170,7 +170,7 @@ struct session * ac_session_load(const char * filename)
                 if (chdir(line) == -1) {
                     free(line);
                     fclose(f);
-                    ac_session_destroy(ret);
+                    ac_session_free(&ret);
                     return NULL;
                 }
                 ret->working_dir = line;
@@ -183,7 +183,7 @@ struct session * ac_session_load(const char * filename)
                 if (strlen(line) != 17) {
                     free(line);
                     fclose(f);
-                    ac_session_destroy(ret);
+                    ac_session_free(&ret);
                     return NULL;
                 }
 
@@ -196,7 +196,7 @@ struct session * ac_session_load(const char * filename)
                 // Verify all parsed correctly
                 if (count < 6) {
                     fclose(f);
-                    ac_session_destroy(ret);
+                    ac_session_free(&ret);
                     return NULL;
                 }
                 
@@ -212,7 +212,7 @@ struct session * ac_session_load(const char * filename)
                     || ret->pos < 0 || ret->nb_keys_tried < 0) {
                     free(line);
                     fclose(f);
-                    ac_session_destroy(ret);
+                    ac_session_free(&ret);
                     return NULL;
                 }
                 break;
@@ -223,7 +223,7 @@ struct session * ac_session_load(const char * filename)
                 free(line);
                 if (sscanf_ret != 1 || ret->argc < 2) {
                     fclose(f);
-                    ac_session_destroy(ret);
+                    ac_session_free(&ret);
                     return NULL;
                 }
 
@@ -231,7 +231,7 @@ struct session * ac_session_load(const char * filename)
                 ret->argv = (char **)calloc(ret->argc, sizeof(char *));
                 if (ret->argv == NULL) {
                     fclose(f);
-                    ac_session_destroy(ret);
+                    ac_session_free(&ret);
                     return NULL;
                 }
 
@@ -248,7 +248,7 @@ struct session * ac_session_load(const char * filename)
     
     fclose(f);
     if (line_nr < SESSION_ARGUMENTS_LINE + 1) {
-        ac_session_destroy(ret);
+        ac_session_free(&ret);
         return NULL;
     }
     

--- a/src/session.c
+++ b/src/session.c
@@ -134,7 +134,11 @@ struct session * ac_session_load(const char * filename)
     }
     
     // Check size isn't 0
-    uint64_t fsize = fseeko(f, 0, SEEK_END);
+    if (fseeko(f, 0, SEEK_END)) {
+        fclose(f);
+        return NULL;
+    }
+    uint64_t fsize = ftello(f);
     if (fsize == 0) {
         fclose(f);
         return NULL;

--- a/src/session.c
+++ b/src/session.c
@@ -303,7 +303,7 @@ struct session * new_struct_session(const int argc, char ** argv, const char * f
     return ret;
 }
 
-int save_session_to_file(struct session * s, const unsigned char wordlist_id, const int64_t pos, long long int nb_keys_tried)
+int save_session_to_file(struct session * s, long long int nb_keys_tried)
 {
     if (s == NULL || s->filename == NULL || s->working_dir == NULL
         || s->argc == 0 || s->argv == NULL) {
@@ -315,9 +315,7 @@ int save_session_to_file(struct session * s, const unsigned char wordlist_id, co
         return -1;
     }
 
-    // Update wordlist position, wordlist ID and amount of keys tried in structure
-    s->pos = pos;
-    s->wordlist_id = wordlist_id;
+    // Update amount of keys tried in structure
     s->nb_keys_tried = nb_keys_tried;
 
     // Write it

--- a/src/session.c
+++ b/src/session.c
@@ -196,6 +196,9 @@ static char * ac_session_getline(FILE * f)
 }
 
 /*
+ * MT-Unsafe: Caller must not permit multiple threads to call 
+ * the function with the same session object.
+ * 
  * File format:
  * Line 1: Working directory
  * Line 2: BSSID
@@ -381,6 +384,10 @@ struct session * ac_session_from_argv(const int argc, char ** argv, const char *
     return ret;
 }
 
+/* 
+ * MT-Unsafe: Caller must not permit multiple threads to call 
+ * the function with the same session object.
+ */
 int ac_session_save(struct session * s, long long int nb_keys_tried)
 {
     if (s == NULL || s->filename == NULL || s->working_dir == NULL

--- a/src/session.c
+++ b/src/session.c
@@ -171,7 +171,7 @@ struct session * load_session_file(const char * filename)
             }
             case 2: // Position in file
             {
-                if (sscanf(line, "%d %" PRId64, &(ret->wordlist_id), &(ret->pos)) != 2 || ret->pos < 0) {
+                if (sscanf(line, "%hhu %" PRId64, &(ret->wordlist_id), &(ret->pos)) != 2 || ret->pos < 0) {
                     free(line);
                     fclose(f);
                     free_struct_session(ret);

--- a/src/session.c
+++ b/src/session.c
@@ -178,7 +178,7 @@ struct session * load_session_file(const char * filename)
     return ret;
 }
 
-struct session * new_struct_session(const int argc, const char ** argv, const char * filename)
+struct session * new_struct_session(const int argc, char ** argv, const char * filename)
 {
     if (filename == NULL || filename[0] == 0 || argc <= 3 || argv == NULL) {
         // If it only has this parameter, then there is something wrong

--- a/src/session.c
+++ b/src/session.c
@@ -113,7 +113,7 @@ struct session * load_session_file(const char * filename)
             if (line[strlen(line) - 1] == '\r') line[strlen(line) - 1] = 0;
         }
 
-        // The first 3 parameters cannot be empty
+        // The first 4 parameters cannot be empty
         if (line_nr < SESSION_ARGUMENTS_LINE && strlen(line) == 0) {
             free(line);
             fclose(f);
@@ -158,7 +158,7 @@ struct session * load_session_file(const char * filename)
             }
             case 2: // Position in file
             {
-                if (sscanf(line, "%" PRId64, &(ret->pos)) == 0 || ret->pos < 0) {
+                if (sscanf(line, "%d %" PRId64, &(ret->wordlist_id), &(ret->pos)) != 2 || ret->pos < 0) {
                     free(line);
                     fclose(f);
                     free_struct_session(ret);
@@ -287,7 +287,7 @@ struct session * new_struct_session(const int argc, char ** argv, const char * f
     return ret;
 }
 
-int save_session_to_file(struct session * s, const int64_t pos)
+int save_session_to_file(struct session * s, const unsigned char wordlist_id, const int64_t pos)
 {
     if (s == NULL || s->filename == NULL || s->working_dir == NULL
         || s->argc == 0 || s->argv == NULL) {
@@ -299,13 +299,14 @@ int save_session_to_file(struct session * s, const int64_t pos)
         return -1;
     }
 
-    // Update position in structure
+    // Update wordlist position and ID in structure
     s->pos = pos;
+    s->wordlist_id = wordlist_id;
 
     // Write it
     fprintf(f, "%s\n", s->working_dir);
     fprintf(f, "%02X:%02X:%02X:%02X:%02X:%02X\n", s->bssid[0], s->bssid[1], s->bssid[2], s->bssid[3], s->bssid[4], s->bssid[5]);
-    fprintf(f, "%" PRId64 "\n", s->pos);
+    fprintf(f, "%d %" PRId64 "\n", s->wordlist_id, s->pos);
     fprintf(f, "%d\n", s->argc);
     for (int i = 0; i < s->argc; ++i) {
         fprintf(f, "%s\n", s->argv[i]);

--- a/src/session.c
+++ b/src/session.c
@@ -1,0 +1,262 @@
+/*
+ *  Aircrack-ng session (load/restore).
+ *
+ *  Copyright (C) 2018 Thomas d'Otreppe <tdotreppe@aircrack-ng.org>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *
+ *  In addition, as a special exception, the copyright holders give
+ *  permission to link the code of portions of this program with the
+ *  OpenSSL library under certain conditions as described in each
+ *  individual source file, and distribute linked combinations
+ *  including the two.
+ *  You must obey the GNU General Public License in all respects
+ *  for all of the code used other than OpenSSL. *  If you modify
+ *  file(s) with this exception, you may extend this exception to your
+ *  version of the file(s), but you are not obligated to do so. *  If you
+ *  do not wish to do so, delete this exception statement from your
+ *  version. *  If you delete this exception statement from all source
+ *  files in the program, then also delete it here.
+ */
+
+#include "session.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <errno.h>
+
+void free_struct_session(struct session * s)
+{
+    if (s == NULL) {
+        return;
+    }
+    
+    if (s->filename) free(s->filename);
+    if (s->argv) {
+        for (int i = 0; i < s->argc; ++i) {
+            free(s->argv[i]);
+        }
+        free(s->argv);
+    }
+    if (s->working_dir) free(s->working_dir);
+}
+
+
+#define SESSION_ARGUMENTS_LINE 3
+struct session * load_session_file(const char * filename)
+{
+    // Check if file exists
+    if (filename == NULL || filename[0] == 0) {
+        return NULL;
+    }
+    FILE * f = fopen(filename, "r");
+    if (f == NULL) {
+        return NULL;
+    }
+
+    // Prepare structure
+    struct session * ret = (struct session *)calloc(1, sizeof(struct session));
+    if (ret == NULL) {
+        fclose(f);
+        return NULL;
+    }
+
+    ret->filename = strdup(filename);
+    
+    char * line = NULL;
+    int line_nr = 0;
+    while (1) {
+        ssize_t line_len = getline(&line, 0, f);
+        if (line_len == -1) break;
+        if (line[0] == '#') continue;
+        if (strlen(line) > 0) {
+            if (line[strlen(line) - 1] == '\n') line[strlen(line) - 1] = 0;
+            if (line[strlen(line) - 1] == '\r') line[strlen(line) - 1] = 0;
+        }
+        // The first 3 parameters cannot be empty
+        if (line_nr < SESSION_ARGUMENTS_LINE && strlen(line) == 0) {
+            free(line);
+            fclose(f);
+            free_struct_session(ret);
+            return NULL;
+        }
+        
+        // Check the parameters
+        switch (line_nr) {
+            case 0: // Working directory
+            {
+                if (chdir(line) == -1) {
+                    free(line);
+                    fclose(f);
+                    free_struct_session(ret);
+                    return NULL;
+                }
+                ret->working_dir = line;
+                
+                break;
+            }
+            case 1: // Position in file
+            {
+                if (sscanf(line, "%jd", &(ret->pos)) == 0 || ret->pos < 0) {
+                    free(line);
+                    fclose(f);
+                    free_struct_session(ret);
+                    return NULL;
+                }
+                break;
+            }
+            case 2: // Number of arguments
+            {
+                if (sscanf(line, "%d", &(ret->argc)) == 0 || ret->argc <= 0) {
+                    free(line);
+                    fclose(f);
+                    free_struct_session(ret);
+                    return NULL;
+                }
+                
+                free(line);
+                
+                // Allocate memory for all the arguments
+                ret->argv = (char **)calloc(ret->argc, sizeof(char *));
+                if (ret->argv == NULL) {
+                    fclose(f);
+                    free_struct_session(ret);
+                    return NULL;
+                }
+
+                break;
+            }
+            default: // All the arguments
+            {
+                ret->argv[line_nr - SESSION_ARGUMENTS_LINE] = line;
+                break;
+            }
+        }
+        ++line_nr;
+    }
+    
+    return ret;
+}
+
+struct session * create_new_session(const int argc, const char ** argv, const char * filename)
+{
+    if (filename == NULL || filename[0] == 0 || argc <= 3 || argv == NULL) {
+        // If it only has this parameter, then there is something wrong
+        return NULL;
+    }
+
+    // Check if the file exists and create it if it doesn't
+    int fd = -1;
+    if ((fd = open(filename, O_WRONLY | O_CREAT | O_EXCL, 0666)) >= 0) {
+        // Just create an empty file for now
+        close(fd);
+    } else {
+        // Not overwriting
+        fprintf(stderr, "Session file already exists: %s\n", filename);
+        return NULL;
+    }
+        
+    // Prepare structure
+    struct session * ret = (struct session *)calloc(1, sizeof(struct session));
+    if (ret == NULL) {
+        return NULL;
+    }
+    
+    // Get working directory and copy filename
+    size_t wd_size = 0;
+    char * wd_ret;
+    while (1) {
+        wd_size += PATH_MAX;
+        char * wd_realloc = (char *)realloc(ret->working_dir, wd_size);
+        if (wd_realloc == NULL) {
+            free_struct_session(ret);
+            return NULL;
+        }
+        ret->working_dir = wd_realloc;
+        wd_ret = getcwd(ret->working_dir, wd_size);
+        if (wd_ret == NULL && errno != ERANGE) {
+            free_struct_session(ret);
+            return NULL;
+        }
+    } while (wd_ret == NULL && errno == ERANGE);
+
+    // Copy filename
+    ret->filename = strdup(filename);
+    if (ret->filename == NULL) {
+        free_struct_session(ret);
+        return NULL;
+    }
+
+    // Copy argc and argv, except argv[0] and the 2 specifying session filename location
+    ret->argv = (char **)calloc(argc - 3, sizeof(char *));
+    if (ret->argv == NULL) {
+        free_struct_session(ret);
+        return NULL;
+    }
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], filename) == 0) {
+            // Found the filename, now remove the previously copied argument
+            ret->argc--;
+            free(ret->argv[ret->argc]);
+            ret->argv[ret->argc] = NULL;
+            continue;
+        }
+
+        // Copy argument
+        ret->argv[ret->argc] = strdup(argv[i]);
+        if (ret->argv[ret->argc] == NULL) {
+            free_struct_session(ret);
+            return NULL;
+        }
+
+        // Increment count
+        ret->argc++;
+    }
+    
+    return ret;
+}
+
+int update_session(struct session * s, off_t pos)
+{
+    if (s == NULL || s->filename == NULL || s->working_dir == NULL
+        || s->argc == 0 || s->argv == NULL) {
+        return -1;
+    }
+
+    FILE * f = fopen(s->filename, "w");
+    if (f == NULL) {
+        return -1;
+    }
+
+    // Update position in structure
+    s->pos = pos;
+
+    // Write it
+    fprintf(f, "%s\n", s->working_dir);
+    fprintf(f, "%jd\n", s->pos);
+    fprintf(f, "%d\n", s->argc);
+    for (int i = 0; i < s->argc; ++i) {
+        fprintf(f, "%s\n", s->argv[i]);
+    }
+    fclose(f);
+    
+    return 0;
+}

--- a/src/session.c
+++ b/src/session.c
@@ -272,6 +272,8 @@ struct session * ac_session_load(const char * filename)
     return ret;
 }
 
+// Two arguments will be ignored: Session creation parameter and its argument
+#define AMOUNT_ARGUMENTS_IGNORE 2
 struct session * ac_session_from_argv(const int argc, char ** argv, const char * filename)
 {
     if (filename == NULL || filename[0] == 0 || argc <= 3 || argv == NULL) {
@@ -312,7 +314,7 @@ struct session * ac_session_from_argv(const int argc, char ** argv, const char *
     }
 
     // Copy argc and argv, except the 2 specifying session filename location
-    ret->argv = (char **)calloc(argc - 2, sizeof(char *));
+    ret->argv = (char **)calloc(argc - AMOUNT_ARGUMENTS_IGNORE, sizeof(char *));
     if (ret->argv == NULL) {
         ac_session_free(&ret);
         return NULL;

--- a/src/session.c
+++ b/src/session.c
@@ -95,6 +95,17 @@ struct session * ac_session_new()
     return (struct session *)calloc(1, sizeof(struct session));
 }
 
+int ac_session_init(struct session * s)
+{
+    if (s == NULL) {
+        return EXIT_FAILURE;
+    }
+    
+    memset(s, 0, sizeof(struct session));
+    
+    return EXIT_SUCCESS;
+}
+
 /*
  * File format:
  * Line 1: Working directory
@@ -137,6 +148,8 @@ struct session * ac_session_load(const char * filename)
         return NULL;
     }
 
+    // Initialize
+    ac_session_init(ret);
     ret->filename = strdup(filename);
     
     char * line;
@@ -273,11 +286,12 @@ struct session * ac_session_from_argv(const int argc, char ** argv, const char *
         return NULL;
     }
         
-    // Prepare structure
+    // Initialize structure
     struct session * ret = ac_session_new();
     if (ret == NULL) {
         return NULL;
     }
+    ac_session_init(ret);
 
     // Get working directory and copy filename
     size_t wd_size = 0;

--- a/src/session.c
+++ b/src/session.c
@@ -167,6 +167,7 @@ int ac_session_set_wordlist_settings(struct session * session, const char * str)
     return EXIT_SUCCESS;
 }
 
+#define SESSION_MIN_NBARG 4
 int ac_session_set_amount_arguments(struct session * session, const char * str)
 {
     if (session == NULL || str == NULL) {
@@ -175,7 +176,12 @@ int ac_session_set_amount_arguments(struct session * session, const char * str)
 
     // Parse amount of arguments
     int nb_input_scanned = sscanf(str, "%d", &(session->argc));
-    if (nb_input_scanned != 1 || session->argc < 2) { // There should be at least 2 arguments
+    if (nb_input_scanned != 1 || session->argc < SESSION_MIN_NBARG) {
+        // There should be at least 4 arguments:
+        // - Executable path (argv[0])
+        // - -w
+        // - Wordlist
+        // - capture file
         return EXIT_FAILURE;
     }
 

--- a/src/session.h
+++ b/src/session.h
@@ -38,15 +38,16 @@
 #include <inttypes.h>
 
 struct session {
-    char * filename;
+    char * filename; // Session filename
 
-    char * working_dir; // Line 1
-    unsigned char bssid[6]; // Line 2
-    unsigned char wordlist_id; // Line 3
-    int64_t pos; // Line 3
-    long long int nb_keys_tried; // Line 3
-    int argc; // Line 4
-    char ** argv; // Arguments
+    // Session file content
+    char * working_dir; // Line 1: Current working directory
+    unsigned char bssid[6]; // Line 2: BSSID
+    unsigned char wordlist_id; // Line 3: Wordlist # (there can be multiple wordlist loaded using -w
+    int64_t pos; // Line 3: Position in the wordlist ID.
+    long long int nb_keys_tried; // Line 3: Amount of keys already tried, purely for stats
+    int argc; // Line 4: amount of arguments
+    char ** argv; // Line 5 and further: Arguments (1 per line)
 };
 
 struct session * ac_session_new();

--- a/src/session.h
+++ b/src/session.h
@@ -43,13 +43,13 @@ struct session {
     int argc;
     char * working_dir;
     int64_t pos;
-    uint8_t bssid[6];
+    unsigned char bssid[6];
 };
 
 void free_struct_session(struct session * s);
 struct session * load_session_file(const char * filename);
 
-struct session * new_struct_session(const int argc, const char ** argv, const char * filename);
+struct session * new_struct_session(const int argc, char ** argv, const char * filename);
 int save_session_to_file(struct session * s, int64_t pos);
 
 #endif // _AIRCRACK_NG_SESSION_H

--- a/src/session.h
+++ b/src/session.h
@@ -39,12 +39,13 @@
 
 struct session {
     char * filename;
-    char ** argv;
-    int argc;
-    char * working_dir;
-    int64_t pos;
-    unsigned char wordlist_id;
-    unsigned char bssid[6];
+
+    char * working_dir; // Line 1
+    unsigned char bssid[6]; // Line 2
+    unsigned char wordlist_id; // Line 3
+    int64_t pos; // Line 3
+    int argc; // Line 4
+    char ** argv; // Arguments
 };
 
 int delete_session_file(struct session * s);

--- a/src/session.h
+++ b/src/session.h
@@ -46,7 +46,7 @@ struct session {
     unsigned char bssid[6];
 };
 
-void free_struct_session(struct session * s);
+void free_struct_session(struct session * s, int delete_file);
 struct session * load_session_file(const char * filename);
 
 struct session * new_struct_session(const int argc, char ** argv, const char * filename);

--- a/src/session.h
+++ b/src/session.h
@@ -46,7 +46,8 @@ struct session {
     unsigned char bssid[6];
 };
 
-void free_struct_session(struct session * s, int delete_file);
+int delete_session_file(struct session * s);
+void free_struct_session(struct session * s);
 struct session * load_session_file(const char * filename);
 
 struct session * new_struct_session(const int argc, char ** argv, const char * filename);

--- a/src/session.h
+++ b/src/session.h
@@ -43,6 +43,7 @@ struct session {
     int argc;
     char * working_dir;
     int64_t pos;
+    unsigned char wordlist_id;
     unsigned char bssid[6];
 };
 

--- a/src/session.h
+++ b/src/session.h
@@ -55,7 +55,16 @@ int ac_session_destroy(struct session * s);
 void ac_session_free(struct session ** s);
 int ac_session_init(struct session * s);
 
+// Validate and set the different values in the session structure
+int ac_session_set_working_directory(struct session * session, const char * str);
+int ac_session_set_bssid(struct session * session, const char * str);
+int ac_session_set_wordlist_settings(struct session * session, const char * str);
+int ac_session_set_amount_arguments(struct session * session, const char * str);
+
+// Load from file
 struct session * ac_session_load(const char * filename);
+
+// Save to file
 int ac_session_save(struct session * s, long long int nb_keys_tried);
 
 struct session * ac_session_from_argv(const int argc, char ** argv, const char * filename);

--- a/src/session.h
+++ b/src/session.h
@@ -54,6 +54,6 @@ void free_struct_session(struct session * s);
 struct session * load_session_file(const char * filename);
 
 struct session * new_struct_session(const int argc, char ** argv, const char * filename);
-int save_session_to_file(struct session * s, const unsigned char wordlist_id, const int64_t pos, long long int nb_keys_tried);
+int save_session_to_file(struct session * s, long long int nb_keys_tried);
 
 #endif // _AIRCRACK_NG_SESSION_H

--- a/src/session.h
+++ b/src/session.h
@@ -52,7 +52,7 @@ struct session {
 struct session * ac_session_new();
 int ac_session_destroy(struct session * s);
 void ac_session_free(struct session ** s);
-
+int ac_session_init(struct session * s);
 
 struct session * ac_session_load(const char * filename);
 int ac_session_save(struct session * s, long long int nb_keys_tried);

--- a/src/session.h
+++ b/src/session.h
@@ -53,6 +53,6 @@ void free_struct_session(struct session * s);
 struct session * load_session_file(const char * filename);
 
 struct session * new_struct_session(const int argc, char ** argv, const char * filename);
-int save_session_to_file(struct session * s, const int64_t pos);
+int save_session_to_file(struct session * s, const unsigned char wordlist_id, const int64_t pos);
 
 #endif // _AIRCRACK_NG_SESSION_H

--- a/src/session.h
+++ b/src/session.h
@@ -49,11 +49,15 @@ struct session {
     char ** argv; // Arguments
 };
 
-int delete_session_file(struct session * s);
-void free_struct_session(struct session * s);
-struct session * load_session_file(const char * filename);
+struct session * ac_session_new();
+int ac_session_destroy(struct session * s);
+void ac_session_free(struct session ** s);
 
-struct session * new_struct_session(const int argc, char ** argv, const char * filename);
-int save_session_to_file(struct session * s, long long int nb_keys_tried);
+
+struct session * ac_session_load(const char * filename);
+int ac_session_save(struct session * s, long long int nb_keys_tried);
+
+struct session * ac_session_from_argv(const int argc, char ** argv, const char * filename);
+
 
 #endif // _AIRCRACK_NG_SESSION_H

--- a/src/session.h
+++ b/src/session.h
@@ -35,19 +35,21 @@
 #ifndef _AIRCRACK_NG_SESSION_H
 #define _AIRCRACK_NG_SESSION_H
 
-#include <stdio.h>
+#include <inttypes.h>
 
 struct session {
     char * filename;
     char ** argv;
     int argc;
     char * working_dir;
-    off_t pos;
+    int64_t pos;
+    uint8_t bssid[6];
 };
 
 void free_struct_session(struct session * s);
 struct session * load_session_file(const char * filename);
-struct session * create_new_session(const int argc, const char ** argv, const char * filename);
-int update_session(struct session * s, off_t pos);
+
+struct session * new_struct_session(const int argc, const char ** argv, const char * filename);
+int save_session_to_file(struct session * s, int64_t pos);
 
 #endif // _AIRCRACK_NG_SESSION_H

--- a/src/session.h
+++ b/src/session.h
@@ -1,0 +1,53 @@
+/*
+ *  Aircrack-ng session (load/restore).
+ *
+ *  Copyright (C) 2018 Thomas d'Otreppe <tdotreppe@aircrack-ng.org>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *
+ *  In addition, as a special exception, the copyright holders give
+ *  permission to link the code of portions of this program with the
+ *  OpenSSL library under certain conditions as described in each
+ *  individual source file, and distribute linked combinations
+ *  including the two.
+ *  You must obey the GNU General Public License in all respects
+ *  for all of the code used other than OpenSSL. *  If you modify
+ *  file(s) with this exception, you may extend this exception to your
+ *  version of the file(s), but you are not obligated to do so. *  If you
+ *  do not wish to do so, delete this exception statement from your
+ *  version. *  If you delete this exception statement from all source
+ *  files in the program, then also delete it here.
+ */
+
+#ifndef _AIRCRACK_NG_SESSION_H
+#define _AIRCRACK_NG_SESSION_H
+
+#include <stdio.h>
+
+struct session {
+    char * filename;
+    char ** argv;
+    int argc;
+    char * working_dir;
+    off_t pos;
+};
+
+void free_struct_session(struct session * s);
+struct session * load_session_file(const char * filename);
+struct session * create_new_session(const int argc, const char ** argv, const char * filename);
+int update_session(struct session * s, off_t pos);
+
+#endif // _AIRCRACK_NG_SESSION_H

--- a/src/session.h
+++ b/src/session.h
@@ -50,6 +50,6 @@ void free_struct_session(struct session * s);
 struct session * load_session_file(const char * filename);
 
 struct session * new_struct_session(const int argc, char ** argv, const char * filename);
-int save_session_to_file(struct session * s, int64_t pos);
+int save_session_to_file(struct session * s, const int64_t pos);
 
 #endif // _AIRCRACK_NG_SESSION_H

--- a/src/session.h
+++ b/src/session.h
@@ -36,6 +36,7 @@
 #define _AIRCRACK_NG_SESSION_H
 
 #include <inttypes.h>
+#include <pthread.h>
 
 struct session {
     char * filename; // Session filename
@@ -48,6 +49,7 @@ struct session {
     long long int nb_keys_tried; // Line 3: Amount of keys already tried, purely for stats
     int argc; // Line 4: amount of arguments
     char ** argv; // Line 5 and further: Arguments (1 per line)
+    pthread_mutex_t mutex; // Locking for when updating wordlist settings and saving file
 };
 
 struct session * ac_session_new();
@@ -65,7 +67,7 @@ int ac_session_set_amount_arguments(struct session * session, const char * str);
 struct session * ac_session_load(const char * filename);
 
 // Save to file
-int ac_session_save(struct session * s, long long int nb_keys_tried);
+int ac_session_save(struct session * s, uint64_t pos, long long int nb_keys_tried);
 
 struct session * ac_session_from_argv(const int argc, char ** argv, const char * filename);
 

--- a/src/session.h
+++ b/src/session.h
@@ -44,6 +44,7 @@ struct session {
     unsigned char bssid[6]; // Line 2
     unsigned char wordlist_id; // Line 3
     int64_t pos; // Line 3
+    long long int nb_keys_tried; // Line 3
     int argc; // Line 4
     char ** argv; // Arguments
 };
@@ -53,6 +54,6 @@ void free_struct_session(struct session * s);
 struct session * load_session_file(const char * filename);
 
 struct session * new_struct_session(const int argc, char ** argv, const char * filename);
-int save_session_to_file(struct session * s, const unsigned char wordlist_id, const int64_t pos);
+int save_session_to_file(struct session * s, const unsigned char wordlist_id, const int64_t pos, long long int nb_keys_tried);
 
 #endif // _AIRCRACK_NG_SESSION_H

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -66,6 +66,7 @@ TESTS = test-hex_string_to_array.sh \
 		test-aircrack-ng-0003.sh \
 		test-aircrack-ng-0004.sh \
 		test-aircrack-ng-0005.sh \
+		test-aircrack-ng-0006.sh \
 		test-airdecap-ng-0001.sh \
 		test-airdecap-ng-0002.sh \
 		test-airdecap-ng-0003.sh \
@@ -83,6 +84,7 @@ EXTRA_DIST = test-hex_string_to_array.sh \
 			 test-aircrack-ng-0003.sh \
 			 test-aircrack-ng-0004.sh \
 			 test-aircrack-ng-0005.sh \
+			 test-aircrack-ng-0006.sh \
 			 test-airdecap-ng-0001.sh \
 			 test-airdecap-ng-0002.sh \
 			 test-airdecap-ng-0003.sh \

--- a/test/test-aircrack-ng-0006.sh
+++ b/test/test-aircrack-ng-0006.sh
@@ -5,7 +5,7 @@ set -ef
 cat > session << EOF
 ${abs_srcdir}
 00:0D:93:EB:B0:8C
-0 0
+0 0 0
 4
 ${top_builddir}/src/aircrack-ng${EXEEXT}
 ${abs_srcdir}/wpa.cap

--- a/test/test-aircrack-ng-0006.sh
+++ b/test/test-aircrack-ng-0006.sh
@@ -2,7 +2,7 @@
 
 set -ef
 
-echo "asciipsk" > 1word
+echo "asciipsk" > ${abs_srcdir}/1word
 
 cat > session << EOF
 ${abs_srcdir}
@@ -12,7 +12,7 @@ ${abs_srcdir}
 ${top_builddir}/src/aircrack-ng${EXEEXT}
 ${abs_srcdir}/wpa.cap
 -w
-1word,${abs_srcdir}/password.lst
+${abs_srcdir}/1word,${abs_srcdir}/password.lst
 EOF
 
 "${top_builddir}/src/aircrack-ng${EXEEXT}" \

--- a/test/test-aircrack-ng-0006.sh
+++ b/test/test-aircrack-ng-0006.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -ef
+
+cat > session << EOF
+${abs_srcdir}
+00:0D:93:EB:B0:8C
+0 0
+4
+${top_builddir}/src/aircrack-ng${EXEEXT}
+${abs_srcdir}/wpa.cap
+-w
+${abs_srcdir}/password.lst
+EOF
+
+
+"${top_builddir}/src/aircrack-ng${EXEEXT}" \
+    -R ${abs_srcdir}/session | \
+        grep 'KEY FOUND! \[ biscotte \]'
+
+if [ -f session ]; then
+	rm session
+	exit 1
+fi
+
+exit 0
+

--- a/test/test-aircrack-ng-0006.sh
+++ b/test/test-aircrack-ng-0006.sh
@@ -2,21 +2,24 @@
 
 set -ef
 
+echo "asciipsk" > 1word
+
 cat > session << EOF
 ${abs_srcdir}
 00:0D:93:EB:B0:8C
-0 0 0
+1 0 0
 4
 ${top_builddir}/src/aircrack-ng${EXEEXT}
 ${abs_srcdir}/wpa.cap
 -w
-${abs_srcdir}/password.lst
+1word,${abs_srcdir}/password.lst
 EOF
-
 
 "${top_builddir}/src/aircrack-ng${EXEEXT}" \
     -R ${abs_srcdir}/session | \
         grep 'KEY FOUND! \[ biscotte \]'
+
+rm -f 1word
 
 if [ -f session ]; then
 	rm session


### PR DESCRIPTION
Cracking is can be a time consuming task and sometimes needs to be paused and restarted later on.

This PR allows to create and restore/continue session ONLY when one or more wordlists are used. It works with WEP and WPA (and WPA2). Limitations:
- None of the wordlists provided can be `stdin` (aka '-' parameter for `-w`).
- It doesn't work with airolib-ng databases.

When creating a session (or restoring one), a separate thread will be created so it disturb the cracking process as little as possible. This thread will save the session every 10 minutes.

Manpage has also been updated and a test created (`make check`).

See #22.