### PR TITLE
[airmon-ng] fix the 88XXau support

### DIFF
--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -438,7 +438,7 @@ startMac80211Iface() {
 		fi
 		#we didn't bail means our target interface is available
 		setLink ${1} down
-		if [ "${DRIVER}" = "8812au" ] || [ "${DRIVER}" = "8814au" ] || [ "${DRIVER}" = "rtl8812au" ]; then
+		if [ "${DRIVER}" = "8812au" ] || [ "${DRIVER}" = "8814au" ] || [ "${DRIVER}" = "rtl8812au" ] || [ "${DRIVER}" = "rtl88xxau" ]; then
 			#grumble grumble, seriously crap vendor driver
 			startDeprecatedIface ${1}
 			setChannelMac80211 ${1}
@@ -593,7 +593,7 @@ stopMac80211Iface() {
 			printf "please report it.\n"
 			exit 1
 		else
-			if [ "${DRIVER}" = "8812au" ] || [ "${DRIVER}" = "8814au" ] || [ "${DRIVER}" = "rtl8812au" ]; then
+			if [ "${DRIVER}" = "8812au" ] || [ "${DRIVER}" = "8814au" ] || [ "${DRIVER}" = "rtl8812au" ] || [ "${DRIVER}" = "rtl88xxau" ]; then
 				#grumble grumble, seriously crap vendor driver
 				stopDeprecatedIface ${1}
 				return


### PR DESCRIPTION
We've enabled all chipsets to be supported under 1 name if they all are enabled, instead of compiling them separated they all are supported under the "88XXau" or "rtl88xxau" solution.

Left the other names "8812", "8814" and "8821" be there, in case users simply want to compile them separated.