### PR TITLE
Fix build with mmx

### DIFF
--- a/src/aircrack-crypto/arch.h
+++ b/src/aircrack-crypto/arch.h
@@ -357,9 +357,6 @@
 #elif __SSE2__
 #define SIMD_COEF_32 4
 #define SIMD_COEF_64 2
-#elif __MMX__
-#define SIMD_COEF_32 2
-#define SIMD_COEF_64 1
 #endif
 
 /*

--- a/src/aircrack-crypto/memory.h
+++ b/src/aircrack-crypto/memory.h
@@ -70,9 +70,6 @@
 #elif __SSE2__
 #define SIMD_COEF_32 4
 #define SIMD_COEF_64 2
-#elif __MMX__
-#define SIMD_COEF_32 2
-#define SIMD_COEF_64 1
 #endif
 
 /*

--- a/src/aircrack-crypto/pseudo_intrinsics.h
+++ b/src/aircrack-crypto/pseudo_intrinsics.h
@@ -658,15 +658,6 @@ _inline __m128i _mm_set1_epi64(long long a)
 	(vtype)(vtype64) { x0, x1 }
 #endif
 
-/******************************** MMX *********************************/
-
-#elif __MMX__
-#include <mmintrin.h>
-
-typedef __m64i vtype;
-
-#error MMX intrinsics not implemented (contributions are welcome!)
-
 #endif /* __SIMD__ elif __SIMD__ elif __SIMD__ */
 
 /************************* COMMON STUFF BELOW *************************/


### PR DESCRIPTION
Commit 39387fc80f90f3a9ac9ef9f3aa32da5776a0721e removed mmx support
however aircrack-ng fails to build on platforms with mmx because an
error is raised if __MMX__ is defined.

Fixes:
 - http://autobuild.buildroot.net/results/b7362b69435e9ef6fb2aedc50743e88dbd7a5c72

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>