### PR TITLE
Cleanup OpenSSL includes

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -32,6 +32,17 @@
 
  */
 
+
+#ifdef USE_GCRYPT
+#include "gcrypt-openssl-wrapper.h"
+#include "sha1-git.h"
+#else
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+// We don't use EVP. Bite me
+#include <openssl/rc4.h>
+#include <openssl/aes.h>
+#endif
 #include <string.h>
 #include <arpa/inet.h>
 #include <assert.h>

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -35,6 +35,10 @@
 #ifndef _CRYPTO_H
 #define _CRYPTO_H
 
+#ifdef USE_GCRYPT
+#include "gcrypt-openssl-wrapper.h"
+#endif
+
 #define S_LLC_SNAP "\xAA\xAA\x03\x00\x00\x00"
 #define S_LLC_SNAP_ARP (S_LLC_SNAP "\x08\x06")
 #define S_LLC_SNAP_WLCCP "\xAA\xAA\x03\x00\x40\x96\x00\x00"

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -29,23 +29,11 @@
  * do not wish to do so, delete this exception statement from your
  * version.  If you delete this exception statement from all source
  * files in the program, then also delete it here.
- 
+
  */
 
 #ifndef _CRYPTO_H
 #define _CRYPTO_H
-#include <sys/types.h>
-
-#ifdef USE_GCRYPT
-#include "gcrypt-openssl-wrapper.h"
-#include "sha1-git.h"
-#else
-#include <openssl/hmac.h>
-#include <openssl/sha.h>
-// We don't use EVP. Bite me
-#include <openssl/rc4.h>
-#include <openssl/aes.h>
-#endif
 
 #define S_LLC_SNAP "\xAA\xAA\x03\x00\x00\x00"
 #define S_LLC_SNAP_ARP (S_LLC_SNAP "\x08\x06")

--- a/src/ivstools.c
+++ b/src/ivstools.c
@@ -35,6 +35,7 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <time.h>
 
 #include "version.h"


### PR DESCRIPTION
Pushes our OpenSSL includes down into the C file so that our other utilities don’t have to import a bunch of headers. This is possible because we don’t expose any OpenSSL types in the header.
We also don’t actually use sys/types in this file.

We also had a hidden dep that got pulled in from this. Turns out we need Malloc and Free in ivstool. (Which pulling in OpenSSL headers gave us before)