### PR TITLE
[aircrack-ng] faster station lookups

### DIFF
--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -348,22 +348,12 @@ static void destroy_ap(struct AP_info *ap)
 		ap->ivbuf = NULL;
 	}
 
-    void *key = NULL;
+	void *key = NULL;
 	while (c_avl_pick(ap->stations, &key, (void **) &st_tmp) == 0)
 	{
 		free(st_tmp);
 	}
-    c_avl_destroy(ap->stations);
-
-    /*
-	while (ap->st_1st != NULL)
-	{
-		st_tmp = ap->st_1st;
-		ap->st_1st = ap->st_1st->next;
-		free(st_tmp);
-		st_tmp = NULL;
-	}
-    */
+	c_avl_destroy(ap->stations);
 
 	uniqueiv_wipe(ap->uiv_root);
 	ap->uiv_root = NULL;
@@ -1365,7 +1355,7 @@ static int packet_reader__update_ap_info(struct AP_info *ap_cur, int fmt, unsign
 		memset(st_cur, 0, sizeof(struct ST_info));
 
 		memcpy(st_cur->stmac, stmac, sizeof(st_cur->stmac));
-        c_avl_insert(ap_cur->stations, st_cur->stmac, st_cur);
+		c_avl_insert(ap_cur->stations, st_cur->stmac, st_cur);
 	}
 
 skip_station:

--- a/src/aircrack-ng.h
+++ b/src/aircrack-ng.h
@@ -221,7 +221,7 @@ struct AP_info
 	int eapol; /* set if EAPOL is present      */
 	int target; /* flag set if AP is a target   */
 	struct ST_info *st_1st; /* DEPRECATED: linked list of stations */
-    c_avl_tree_t *stations; /* AVL tree of stations keyed on MAC*/
+	c_avl_tree_t *stations; /* AVL tree of stations keyed on MAC*/
 	struct WPA_hdsk wpa; /* valid WPA handshake data     */
 	PTW_attackstate *ptw_clean;
 	PTW_attackstate *ptw_vague;

--- a/src/aircrack-ng.h
+++ b/src/aircrack-ng.h
@@ -47,6 +47,7 @@
 #include "aircrack-crypto/crypto_engine.h"
 
 #include <pthread.h>
+#include "aircrack-util/avl_tree.h"
 
 #define SUCCESS 0
 #define FAILURE 1
@@ -219,7 +220,8 @@ struct AP_info
 	int crypt; /* encryption algorithm         */
 	int eapol; /* set if EAPOL is present      */
 	int target; /* flag set if AP is a target   */
-	struct ST_info *st_1st; /* linked list of stations      */
+	struct ST_info *st_1st; /* DEPRECATED: linked list of stations */
+    c_avl_tree_t *stations; /* AVL tree of stations keyed on MAC*/
 	struct WPA_hdsk wpa; /* valid WPA handshake data     */
 	PTW_attackstate *ptw_clean;
 	PTW_attackstate *ptw_vague;
@@ -228,9 +230,9 @@ struct AP_info
 struct ST_info
 {
 	struct AP_info *ap; /* parent AP                    */
-	struct ST_info *next; /* next supplicant              */
-	struct WPA_hdsk wpa; /* WPA handshake data           */
-	unsigned char stmac[6]; /* client MAC address           */
+	struct ST_info *next; /* DEPRECATED: next supplicant*/
+	struct WPA_hdsk wpa; /* WPA handshake data          */
+	unsigned char stmac[6]; /* client MAC address       */
 };
 
 struct mergeBSSID


### PR DESCRIPTION
Includes https://github.com/aircrack-ng/aircrack-ng/pull/1959 needed for testing.

As mentioned in the other PR this does:
> replace st_cur linked list with avl_tree (this is still the hot instruction for large pcaps)

The hot instructions are still getting the station/AP (`c_avl_get`) and comparing MACs (`compare_stations`) used for traversing the tree.
This does it in log(n) time though instead of linear.

The approach here is to go piecewise as each binary/tool will have to be updated to use a tree, thus deprecating the linked list and adding the new element.

So until the other PR is merged, this may be a more useful diff:
https://github.com/ChrisLundquist/aircrack-ng/compare/clundquist/low-mem-two-pass...ChrisLundquist:clundquist/faster-stations?expand=1

Unscientific testing shows it finishes before I give up.
Ballpark, 200 / 6 min means we average parsing 550MB/s.
NOTE: when `-b` is set we seem to get disk limited, which is where we want to be.
without `-b` we're CPU/memory latency limited.
```
Device            r/s     w/s     rMB/s     wMB/s   rrqm/s   wrqm/s  %rrqm  %wrqm r_await w_await aqu-sz rareq-sz wareq-sz  svctm  %util
# ...
nvme0n1       9057.50    9.30   1129.50      0.07     0.00     7.20   0.00  43.64    0.51    0.65   3.99   127.70     8.09   0.11  99.08
```
```
du -h -d0 /srv/wifi/
201G	/srv/wifi/

$ time  ./src/aircrack-ng /srv/wifi/*.pcapdump

 CC=clang CFLAGS=-g -O0 CXX=clang++ --no-create --no-recursion
# Gave up
Quitting aircrack-ng...
EXIT
real    9m50.619s
user    14m14.887s
sys 19m3.744s


# Finished with AVL tree
Quitting aircrack-ng...
EXIT
real    8m38.445s
user    12m43.133s
sys 20m14.234s


CXX=clang++ CC=clang CFLAGS="-g -O3 -march=skylake"
# Gave up
real    9m57.406s
user    13m19.697s
sys 15m50.740s


# Finished with AVL tree
real    6m14.828s
user    9m3.712s
sys 16m33.883s
```