### PR TITLE
print a helpful breadcrumb when we print the chooser

### DIFF
--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -5970,7 +5970,7 @@ int main(int argc, char *argv[])
 	{
 		if (!opt.is_quiet)
 		{
-			printf("Reading packets, please wait...\r");
+			printf("Generating summary for target selection, please wait...\n");
 			fflush(stdout);
 		}
 
@@ -6179,8 +6179,16 @@ int main(int argc, char *argv[])
 			{
 				// no access points
 			}
-
-			printf("\n");
+			if (!opt.is_quiet)
+			{
+				printf("Use %s -e %s or %s -b %02X:%02X:%02X:%02X:%02X:%02X to load this target faster\n", argv[0], ap_cur->essid, argv[0],
+						ap_cur->bssid[0],
+						ap_cur->bssid[1],
+						ap_cur->bssid[2],
+						ap_cur->bssid[3],
+						ap_cur->bssid[4],
+						ap_cur->bssid[5]);
+			}
 
 			// Release memory of all APs we don't care about currently.
 			ap_avl_release_unused(ap_cur);

--- a/src/aircrack-ng.c
+++ b/src/aircrack-ng.c
@@ -6179,9 +6179,11 @@ int main(int argc, char *argv[])
 			{
 				// no access points
 			}
+			// Release memory of all APs we don't care about currently.
+			ap_avl_release_unused(ap_cur);
 			if (!opt.is_quiet)
 			{
-				printf("Use %s -e %s or %s -b %02X:%02X:%02X:%02X:%02X:%02X to load this target faster\n", argv[0], ap_cur->essid, argv[0],
+				printf("Use %s -b %02X:%02X:%02X:%02X:%02X:%02X to load this target faster\n", argv[0],
 						ap_cur->bssid[0],
 						ap_cur->bssid[1],
 						ap_cur->bssid[2],
@@ -6189,9 +6191,6 @@ int main(int argc, char *argv[])
 						ap_cur->bssid[4],
 						ap_cur->bssid[5]);
 			}
-
-			// Release memory of all APs we don't care about currently.
-			ap_avl_release_unused(ap_cur);
 
 			memcpy(opt.bssid, ap_cur->bssid, 6);
 			opt.bssid_set = 1;
@@ -6291,7 +6290,6 @@ int main(int argc, char *argv[])
 	c_avl_iterator_destroy(it);
 	it = NULL;
 
-	printf("%d potential targets\n\n", c_avl_size(targets));
 	ap_cur = get_first_target();
 
 	if (ap_cur == NULL)
@@ -6300,6 +6298,18 @@ int main(int argc, char *argv[])
 			   (opt.essid_set) ? "essid" : "bssid");
 
 		goto exit_main;
+	}
+
+	if (!opt.is_quiet)
+	{
+		printf("%d potential targets\n\n", c_avl_size(targets));
+		printf("essid: \"%s\" bssid: \"%02X:%02X:%02X:%02X:%02X:%02X\"\n", ap_cur->essid,
+				ap_cur->bssid[0],
+				ap_cur->bssid[1],
+				ap_cur->bssid[2],
+				ap_cur->bssid[3],
+				ap_cur->bssid[4],
+				ap_cur->bssid[5]);
 	}
 
 	if (ap_cur->crypt < 2)


### PR DESCRIPTION
This makes it easier for users to take the fast path / single pass
```
# When I don't know what networks there are in a pcap
$ ./src/aircrack-ng /srv/wifi/home-01.pcapdump
# ...
Index number of target network ? 675
Use ./src/aircrack-ng -b F8:1D:0F:01:88:08 to load this target faster
Opening /srv/wifi/home-01.pcapdump
Read 11246612 packets.

1 potential targets

essid: "<redacted>" bssid: "F8:1D:0F:01:88:08"
Please specify a dictionary (option -w).

# When I know the target
 $ ./src/aircrack-ng  /srv/wifi/home-01.pcapdump -b F8:1D:0F:01:88:08
Opening /srv/wifi/home-01.pcapdump
Read 11246612 packets.

1 potential targets

essid: "<redacted>" bssid: "F8:1D:0F:01:88:08"
Please specify a dictionary (option -w).
```