### PR TITLE
comprehensive json-output, record rx-power per interface

### DIFF
--- a/manpages/airodump-ng.8
+++ b/manpages/airodump-ng.8
@@ -72,7 +72,7 @@ Display APs uptime obtained from its beacon timestamp.
 Display a WPS column with WPS version, config method(s), AP Setup Locked obtained from APs beacon or probe response (if any).
 .TP
 .I --output-format <formats>
-Define the formats to use (separated by a comma). Possible values are: pcap, ivs, csv, gps, kismet, netxml. The default values are: pcap, csv, kismet, kismet-newcore.
+Define the formats to use (separated by a comma). Possible values are: pcap, ivs, csv, gps, kismet, netxml, json. The default values are: pcap, csv, kismet, kismet-newcore.
 \(aqpcap\(aq is for recording a capture in pcap format, \(aqivs\(aq is for ivs format (it is a shortcut for --ivs). \(aqcsv\(aq will create an airodump-ng CSV file, \(aqkismet\(aq will create a kismet csv file and \(aqkismet-newcore\(aq will create the kismet netxml file. \(aqgps\(aq is a shortcut for --gps.
 .br
 Theses values can be combined with the exception of ivs and pcap.

--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -729,7 +729,8 @@ char usage[] =
 	"      --wps                 : Display WPS information (if any)\n"
 	"      --output-format\n"
 	"                  <formats> : Output format. Possible values:\n"
-	"                              pcap, ivs, csv, gps, kismet, netxml\n"
+	"                              pcap, ivs, csv, gps, kismet,\n"
+	"                              netxml, json"
 	"      --ignore-negative-one : Removes the message that says\n"
 	"                              fixed channel <interface>: -1\n"
 	"      --write-interval\n"
@@ -4808,7 +4809,7 @@ static int dump_write_json(void)
 	fprintf(G.f_json, "],\r\n");
 
 
-   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+   /* ouput stations */
 
 	fprintf(G.f_json,
 			"\"st\":[");
@@ -4920,7 +4921,7 @@ static int dump_write_json(void)
 	fprintf(G.f_json, "],\r\n");
 
 
-   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+   /* output not associated */
 
 	fprintf(G.f_json, "\"na\":[");
 
@@ -4988,7 +4989,7 @@ static int dump_write_json(void)
 
 	fprintf(G.f_json, "]}");
 
- //////////////////////////////////////////////////////////////////////////
+ 	/* all done */
 
 	fflush(G.f_json);
 	return 0;

--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -4802,6 +4802,33 @@ static int dump_write_json(void)
 			fprintf(G.f_json, "}");
 		}
 
+		if (G.usegpsd)
+		{
+			fprintf(G.f_json,
+					",{\"gps-info\":"
+					"\"min-lat\":\"%.6f\","
+					"\"min-lon\":\"%.6f\","
+					"\"min-alt\":\"%.6f\","
+					"\"min-spd\":\"%.6f\","
+					"\"max-lat\":\"%.6f\","
+					"\"max-lon\":\"%.6f\","
+					"\"max-alt\":\"%.6f\","
+					"\"max-spd\":\"%.6f\","
+					"\"best-lat\":\"%.6f\","
+					"\"best-lon\":\"%.6f\","
+					"\"best-alt\":\"%.6f\",",
+					ap_cur->gps_loc_min[0],
+					ap_cur->gps_loc_min[1],
+					ap_cur->gps_loc_min[2],
+					ap_cur->gps_loc_min[3],
+					ap_cur->gps_loc_max[0],
+					ap_cur->gps_loc_max[1],
+					ap_cur->gps_loc_max[2],
+					ap_cur->gps_loc_max[3],
+					ap_cur->gps_loc_best[0],
+					ap_cur->gps_loc_best[1],
+					ap_cur->gps_loc_best[2]);
+		}
 
 		fprintf(G.f_json, "}");
 
@@ -4898,10 +4925,14 @@ static int dump_write_json(void)
 		}
 		fprintf(G.f_json, "\",");
 
- 		//missed lastseq bestpower rate_to rate_from no_pkts
 		fprintf(G.f_json,
 				"\"missed\":%d, \"lastseq\":%u, \"best_power\":%d, \"rate_to\":%d, \"rate_from\":%d, \"no_packets\":%lu, ",
-				st_cur->missed, st_cur->lastseq, st_cur->best_power, st_cur->rate_to, st_cur->rate_from, st_cur->nb_pkt);
+				st_cur->missed, 
+				st_cur->lastseq, 
+				st_cur->best_power, 
+				st_cur->rate_to, 
+				st_cur->rate_from, 
+				st_cur->nb_pkt);
 
 		if (G.num_cards > 1) {
 			fprintf(G.f_json, "\"powers\":{");
@@ -4915,6 +4946,35 @@ static int dump_write_json(void)
 			}
 			fprintf(G.f_json, "}");
 		}
+
+
+		if (G.usegpsd)
+		{
+			fprintf(G.f_json,
+					",{\"gps-info\":"
+					"\"min-lat\":\"%.6f\","
+					"\"min-lon\":\"%.6f\","
+					"\"min-alt\":\"%.6f\","
+					"\"min-spd\":\"%.6f\","
+					"\"max-lat\":\"%.6f\","
+					"\"max-lon\":\"%.6f\","
+					"\"max-alt\":\"%.6f\","
+					"\"max-spd\":\"%.6f\","
+					"\"best-lat\":\"%.6f\","
+					"\"best-lon\":\"%.6f\","
+					"\"best-alt\":\"%.6f\",",
+					st_cur->gps_loc_min[0],
+					st_cur->gps_loc_min[1],
+					st_cur->gps_loc_min[2],
+					st_cur->gps_loc_min[3],
+					st_cur->gps_loc_max[0],
+					st_cur->gps_loc_max[1],
+					st_cur->gps_loc_max[2],
+					st_cur->gps_loc_max[3],
+					st_cur->gps_loc_best[0],
+					st_cur->gps_loc_best[1],
+					st_cur->gps_loc_best[2]);
+		}		
 
 		fprintf(G.f_json, "}");
 

--- a/src/airodump-ng.c
+++ b/src/airodump-ng.c
@@ -730,7 +730,7 @@ char usage[] =
 	"      --output-format\n"
 	"                  <formats> : Output format. Possible values:\n"
 	"                              pcap, ivs, csv, gps, kismet,\n"
-	"                              netxml, json"
+	"                              netxml, json\n"
 	"      --ignore-negative-one : Removes the message that says\n"
 	"                              fixed channel <interface>: -1\n"
 	"      --write-interval\n"
@@ -4754,7 +4754,7 @@ static int dump_write_json(void)
 		fprintf(G.f_json, "\",");
 
 		fprintf(G.f_json,
-				"\"avg_power\":%3d, \"no_beacons\":%8lu, \"no_data\":%8lu, ",
+				"\"avg_power\":%d, \"no_beacons\":%lu, \"no_data\":%lu, ",
 				ap_cur->avg_power,
 				ap_cur->nb_bcn,
 				ap_cur->nb_data);
@@ -4766,7 +4766,7 @@ static int dump_write_json(void)
 				ap_cur->lanip[2],
 				ap_cur->lanip[3]);
 
-		fprintf(G.f_json, "\"ssid-len\":%3d, ", ap_cur->ssid_length);
+		fprintf(G.f_json, "\"ssid-len\":%d, ", ap_cur->ssid_length);
 
 		if (verifyssid(ap_cur->essid))
 			fprintf(G.f_json, "\"essid\":\"%s\", ", ap_cur->essid);
@@ -4783,23 +4783,24 @@ static int dump_write_json(void)
 		{
 			for (i = 0; i < (int) strlen(ap_cur->key); i++)
 			{
-				fprintf(G.f_json, "%02X", ap_cur->key[i]);
+				fprintf(G.f_json, "%X", ap_cur->key[i]);
 				if (i < (int) (strlen(ap_cur->key) - 1)) fprintf(G.f_json, ":");
 			}
 		}
 		
 		fprintf(G.f_json, "\", \"no_pkt\":%lu,", ap_cur->nb_pkt);
 
-
-		fprintf(G.f_json, " \"powers\":{");
-		powers_count = 0;
-		for (i=0;i<G.num_cards;i++) {
-			if (ap_cur->powers[i] != -1) {
-				if (powers_count++>0) fprintf(G.f_json,",");
-				fprintf(G.f_json, "\"%s\":%d", G.ifnames[i] , ap_cur->powers[i]);
+		if (G.num_cards > 1) {
+			fprintf(G.f_json, " \"powers\":{");
+			powers_count = 0;
+			for (i=0;i<G.num_cards;i++) {
+				if (ap_cur->powers[i] != -1) {
+					if (powers_count++>0) fprintf(G.f_json,",");
+					fprintf(G.f_json, "\"%s\":%d", G.ifnames[i] , ap_cur->powers[i]);
+				}
 			}
+			fprintf(G.f_json, "}");
 		}
-		fprintf(G.f_json, "}");
 
 
 		fprintf(G.f_json, "}");
@@ -4902,16 +4903,18 @@ static int dump_write_json(void)
 				"\"missed\":%d, \"lastseq\":%u, \"best_power\":%d, \"rate_to\":%d, \"rate_from\":%d, \"no_packets\":%lu, ",
 				st_cur->missed, st_cur->lastseq, st_cur->best_power, st_cur->rate_to, st_cur->rate_from, st_cur->nb_pkt);
 
-		fprintf(G.f_json, "\"powers\":{");
-		powers_count=0;
-		for (i=0;i<G.num_cards;i++) {
-			if (st_cur->powers[i] != -1) {
-				if (powers_count++>0)
-					fprintf(G.f_json, ",");
-				fprintf(G.f_json, "\"%s\":%d", G.ifnames[i] , st_cur->powers[i]);
+		if (G.num_cards > 1) {
+			fprintf(G.f_json, "\"powers\":{");
+			powers_count=0;
+			for (i=0;i<G.num_cards;i++) {
+				if (st_cur->powers[i] != -1) {
+					if (powers_count++>0)
+						fprintf(G.f_json, ",");
+					fprintf(G.f_json, "\"%s\":%d", G.ifnames[i] , st_cur->powers[i]);
+				}
 			}
+			fprintf(G.f_json, "}");
 		}
-		fprintf(G.f_json, "}");
 
 		fprintf(G.f_json, "}");
 
@@ -4961,7 +4964,7 @@ static int dump_write_json(void)
 
 		fprintf(G.f_json, "\"last\":%ld, ", na_cur->tlast);
 
-		fprintf(G.f_json, "\"channel\":%3d, \"power\":%3d, \"no_ack\":%d, \"no_ackps\":%d, \"no_cts\":%d, \"no_rts_r\":%d, \"no_rts_t\":%d, \"no_other\":%d, \"no_packets\":%lu, ", 
+		fprintf(G.f_json, "\"channel\":%d, \"power\":%d, \"no_ack\":%d, \"no_ackps\":%d, \"no_cts\":%d, \"no_rts_r\":%d, \"no_rts_t\":%d, \"no_other\":%d, \"no_packets\":%lu, ", 
 			na_cur->channel, 
 			na_cur->power, 
 			na_cur->ack, 
@@ -4972,16 +4975,18 @@ static int dump_write_json(void)
 			na_cur->other, 
 			na_cur->nb_pkt);
 
-		fprintf(G.f_json, "\"powers\":{"); 
-		 powers_count=0;
-		for (i=0;i<G.num_cards;i++) {
-			if (na_cur->powers[i] != -1) {
-				if (powers_count++>0) 
-					fprintf(G.f_json, ",");
-				fprintf(G.f_json, "\"%s\":%d", G.ifnames[i] , na_cur->powers[i]);
-			}
+		if (G.num_cards > 1) {
+				fprintf(G.f_json, "\"powers\":{"); 
+				powers_count=0;
+				for (i=0;i<G.num_cards;i++) {
+					if (na_cur->powers[i] != -1) {
+						if (powers_count++>0) 
+							fprintf(G.f_json, ",");
+						fprintf(G.f_json, "\"%s\":%d", G.ifnames[i] , na_cur->powers[i]);
+					}
+				}
+				fprintf(G.f_json, "}");
 		}
-		fprintf(G.f_json, "}");
 
 		fprintf(G.f_json, "}");
 		na_cur = na_cur->next;
@@ -8025,7 +8030,7 @@ int main(int argc, char *argv[])
 						{
 							G.output_format_csv = 1;
 						}
-						else if (strncasecmp(output_format_string, "json", 3) == 0)
+						else if (strncasecmp(output_format_string, "json", 4) == 0)
 						{
 							G.output_format_json = 1;
 						}

--- a/src/airodump-ng.h
+++ b/src/airodump-ng.h
@@ -346,6 +346,8 @@ struct NA_info
 	time_t tinit, tlast; /* first and last time seen  */
 	unsigned char namac[6]; /* the stations MAC address  */
 	char *manuf; /* the client's manufacturer */
+	unsigned long nb_pkt; /* total number of packets   */
+
 	int power; /* last signal power         */
 	int powers[MAX_CARDS]; /* power per card */
 

--- a/src/airodump-ng.h
+++ b/src/airodump-ng.h
@@ -37,13 +37,13 @@
 /* some constants */
 
 #define REFRESH_RATE 100000 /* default delay in us between updates */
-#define DEFAULT_HOPFREQ 250 /* default delay in ms between channel hopping */
+#define DEFAULT_HOPFREQ 500 /* default delay in ms between channel hopping */
 #define DEFAULT_CWIDTH 20 /* 20 MHz channels by default */
 
-#define NB_PWR 5 /* size of signal power ring buffer */
-#define NB_PRB 10 /* size of probed ESSID ring buffer */
+#define NB_PWR 20 /* size of signal power ring buffer */
+#define NB_PRB 100 /* size of probed ESSID ring buffer */
 
-#define MAX_CARDS 8 /* maximum number of cards to capture from */
+#define MAX_CARDS 12 /* maximum number of cards to capture from */
 
 #define STD_OPN 0x0001
 #define STD_WEP 0x0002
@@ -244,6 +244,8 @@ struct AP_info
 	int best_power; /* best signal power    */
 	int power_index; /* index in power ring buf. */
 	int power_lvl[NB_PWR]; /* signal power ring buffer */
+	int powers[MAX_CARDS]; /* power per card */
+
 	int preamble; /* 0 = long, 1 = short      */
 	int security; /* ENC_*, AUTH_*, STD_*     */
 	int beacon_logged; /* We need 1 beacon per AP  */
@@ -318,6 +320,8 @@ struct ST_info
 	int ssid_length[NB_PRB]; /* ssid lengths ring buffer  */
 	int power; /* last signal power         */
 	int best_power; /* best signal power    */
+	int powers[MAX_CARDS]; /* power per card */
+
 	int rate_to; /* last bitrate to station   */
 	int rate_from; /* last bitrate from station */
 	struct timeval ftimer; /* time of restart           */
@@ -341,7 +345,10 @@ struct NA_info
 	struct NA_info *next; /* the next client in list   */
 	time_t tinit, tlast; /* first and last time seen  */
 	unsigned char namac[6]; /* the stations MAC address  */
+	char *manuf; /* the client's manufacturer */
 	int power; /* last signal power         */
+	int powers[MAX_CARDS]; /* power per card */
+
 	int channel; /* captured on channel       */
 	int ack; /* number of ACK frames      */
 	int ack_old; /* old number of ACK frames  */
@@ -381,6 +388,8 @@ struct globals
 	FILE *f_cap; /* output cap file      */
 	FILE *f_ivs; /* output ivs file      */
 	FILE *f_xor; /* output prga file     */
+
+    char *ifnames[MAX_CARDS];
 
 	char *batt; /* Battery string       */
 	int channel[MAX_CARDS]; /* current channel #    */

--- a/src/airodump-ng.h
+++ b/src/airodump-ng.h
@@ -106,14 +106,16 @@ get_manufacturer(unsigned char mac0, unsigned char mac1, unsigned char mac2);
 #define KISMET_NETXML_EXT "kismet.netxml"
 #define AIRODUMP_NG_GPS_EXT "gps"
 #define AIRODUMP_NG_CAP_EXT "cap"
+#define AIRODUMP_NG_JSON_EXT "json"
 
-#define NB_EXTENSIONS 6
+#define NB_EXTENSIONS 7
 
 const unsigned char llcnull[4] = {0, 0, 0, 0};
 char *f_ext[NB_EXTENSIONS] = {AIRODUMP_NG_CSV_EXT,
 							  AIRODUMP_NG_GPS_EXT,
 							  AIRODUMP_NG_CAP_EXT,
 							  IVS2_EXTENSION,
+							  AIRODUMP_NG_JSON_EXT
 							  KISMET_CSV_EXT,
 							  KISMET_NETXML_EXT};
 
@@ -387,6 +389,7 @@ struct globals
 	FILE *f_kis; /* output kismet csv file      */
 	FILE *f_kis_xml; /* output kismet netxml file */
 	FILE *f_gps; /* output gps file      */
+	FILE *f_json; /* output json file      */
 	FILE *f_cap; /* output cap file      */
 	FILE *f_ivs; /* output ivs file      */
 	FILE *f_xor; /* output prga file     */
@@ -485,6 +488,7 @@ struct globals
 	int output_format_csv;
 	int output_format_kismet_csv;
 	int output_format_kismet_netxml;
+	int output_format_json;	
 	pthread_t input_tid;
 	int sort_by;
 	int sort_inv;


### PR DESCRIPTION
did a patch that adds very comprehensible json output (that dumps received power per interface, too) for some experiments i currently do. maybe you will find it useful.

changes:
-added dump_write_json() plus supporting glue code
-json also writes rx powers per interfaces, had to add some glue code too (like interface name array)
-also dump non-associated info into json
-changed unknown and unassociated strings to something more unique (some clown here is actually using those)
-json-export obeys --berlin (another clown here is pseudo-randomizing macs)
-powers[] array, pkt_cnt, manufacturer now exists in all ap,st,na structs
-upped MAX_CARDS and increased ring buffers slightly

missing: 
-reset powers[] arrays after channel wrap around (eg, if scanner moves)
