### PR TITLE
fix spelling errors detected on Debian

### DIFF
--- a/build/m4/libgcrypt.m4
+++ b/build/m4/libgcrypt.m4
@@ -19,8 +19,8 @@ dnl MINIMUN-VERSION is a string with the version number optionalliy prefixed
 dnl with the API version to also check the API compatibility. Example:
 dnl a MINIMUN-VERSION of 1:1.2.5 won't pass the test unless the installed
 dnl version of libgcrypt is at least 1.2.5 *and* the API number is 1.  Using
-dnl this features allows to prevent build against newer versions of libgcrypt
-dnl with a changed API.
+dnl this features allows one to prevent build against newer versions of
+dnl libgcrypt with a changed API.
 dnl
 dnl If a prefix option is not used, the config script is first
 dnl searched in $SYSROOT/bin and then along $PATH.  If the used

--- a/manpages/aircrack-ng.1
+++ b/manpages/aircrack-ng.1
@@ -117,7 +117,7 @@ Path to a dictionary file for wpa cracking. Separate filenames with comma when u
 In order to use a dictionary with hexadecimal values, prefix the dictionary with "h:". Each byte in each key must be separated by ':'. When using with WEP, key length should be specified using -n.
 .TP
 .I -N <file> or --new-session <file>
-Create a new cracking session. It allows to interrupt cracking session and restart at a later time (using -R or --restore-session). Status files are saved every 5 minutes. It does not overwrite existing session file.
+Create a new cracking session. It allows one to interrupt cracking session and restart at a later time (using -R or --restore-session). Status files are saved every 5 minutes. It does not overwrite existing session file.
 .TP
 .I -R <file> or --restore-session <file>
 Restore and continue a previously saved cracking session. This parameter is to be used alone, no other parameter should be specified when starting aircrack-ng (all the required information is in the session file).
@@ -147,7 +147,7 @@ Path to the airolib-ng database. Cannot be used with \(aq-w\(aq.
 .B SIMD selection:
 .TP
 .I --simd=<option>
-Aircrack-ng automatically loads and uses the fastest optimization based on instructions available for your CPU. This options allows to force another optimization. Choices depend on the CPU and the following are all the possibilities that may be compiled regardless of the CPU type: generic, sse2, avx, avx2, avx512, neon, asimd, altivec, power8.
+Aircrack-ng automatically loads and uses the fastest optimization based on instructions available for your CPU. This options allows one to force another optimization. Choices depend on the CPU and the following are all the possibilities that may be compiled regardless of the CPU type: generic, sse2, avx, avx2, avx512, neon, asimd, altivec, power8.
 .TP
 .I --simd-list
 Shows a list of the available SIMD architectures, separated by a space character. Aircrack-ng automatically selects the fastest optimization and thus it is rarely needed to use this option. Use case would be for testing purposes or when a "lower" optimization, such as "generic", is faster than the automatically selected one. Before forcing a SIMD architecture, verify that the instruction is supported by your CPU, using \-u.

--- a/manpages/airodump-ng.8
+++ b/manpages/airodump-ng.8
@@ -81,7 +81,7 @@ Theses values can be combined with the exception of ivs and pcap.
 Output file(s) write interval for CSV, Kismet CSV and Kismet NetXML in seconds (minimum: 1 second). By default: 5 seconds. Note that an interval too small might slow down airodump\-ng.
 .TP
 .I -K <enable>, --background <enable>
-Override automatic background detection. Use "0" to force foreground settings and "1" to force background settings. It will not make airodump-ng run as a deamon, it will skip background autodetection and force enable/disable of interactive mode and display updates.
+Override automatic background detection. Use "0" to force foreground settings and "1" to force background settings. It will not make airodump-ng run as a daemon, it will skip background autodetection and force enable/disable of interactive mode and display updates.
 .TP
 .I --ignore-negative-one
 Removes the message that says \(aqfixed channel <interface>: -1\(aq.


### PR DESCRIPTION
Some typos detected while packaging 1.4 for Debian.

Thanks for your attention.