### PR TITLE
ax_ext_have_static_lib.m4: allow overriding lib name

### DIFF
--- a/build/m4/aircrack_ng_crypto.m4
+++ b/build/m4/aircrack_ng_crypto.m4
@@ -45,8 +45,9 @@ AC_ARG_ENABLE(static-crypto,
     [static_crypto=$enableval], [static_crypto=no])
 
 if test "x$static_crypto" != "xno"; then
-	AX_EXT_HAVE_STATIC_LIB(ZLIB, DEFAULT_STATIC_LIB_SEARCH_PATHS, z libz, compress)
-	AX_EXT_HAVE_STATIC_LIB(OPENSSL, DEFAULT_STATIC_LIB_SEARCH_PATHS, crypto libcrypto, HMAC, -lz -ldl)
+	AC_REQUIRE([AX_EXT_HAVE_STATIC_LIB_DETECT])
+	AX_EXT_HAVE_STATIC_LIB(ZLIB, ${DEFAULT_STATIC_LIB_SEARCH_PATHS}, z libz, compress)
+	AX_EXT_HAVE_STATIC_LIB(OPENSSL, ${DEFAULT_STATIC_LIB_SEARCH_PATHS}, crypto libcrypto, HMAC, -lz -ldl)
 else
 	AC_CHECK_LIB([crypto], [OPENSSL_init], [
 		OPENSSL_LIBS="-lcrypto"

--- a/build/m4/aircrack_ng_hwloc.m4
+++ b/build/m4/aircrack_ng_hwloc.m4
@@ -53,9 +53,10 @@ fi
 
 AS_IF([test "x$enable_hwloc" != "xno"], [
 	if test "x$static_hwloc" != "xno"; then
-		AX_EXT_HAVE_STATIC_LIB(HWLOC, DEFAULT_STATIC_LIB_SEARCH_PATHS, hwloc libhwloc, hwloc_bitmap_alloc, -lnuma -lltdl)
-		AX_EXT_HAVE_STATIC_LIB(NUMA, DEFAULT_STATIC_LIB_SEARCH_PATHS, numa libnuma, numa_bitmask_setbit, -lltdl)
-		AX_EXT_HAVE_STATIC_LIB(LTDL, DEFAULT_STATIC_LIB_SEARCH_PATHS, ltdl libltdl, lt_dlopen, -ldl)
+		AC_REQUIRE([AX_EXT_HAVE_STATIC_LIB_DETECT])
+		AX_EXT_HAVE_STATIC_LIB(HWLOC, ${DEFAULT_STATIC_LIB_SEARCH_PATHS}, hwloc libhwloc, hwloc_bitmap_alloc, -lnuma -lltdl)
+		AX_EXT_HAVE_STATIC_LIB(NUMA, ${DEFAULT_STATIC_LIB_SEARCH_PATHS}, numa libnuma, numa_bitmask_setbit, -lltdl)
+		AX_EXT_HAVE_STATIC_LIB(LTDL, ${DEFAULT_STATIC_LIB_SEARCH_PATHS}, ltdl libltdl, lt_dlopen, -ldl)
 		HWLOC_LIBS="$HWLOC_LIBS $NUMA_LIBS $LTDL_LIBS"
 		AC_SUBST([HWLOC_LIBS])
         HAVE_HWLOC=yes

--- a/build/m4/aircrack_ng_pcap.m4
+++ b/build/m4/aircrack_ng_pcap.m4
@@ -103,7 +103,8 @@ dnl Locate the library
 dnl
 AS_IF([test "$PCAP_FOUND" = yes], [
 	if test "x$static_pcap" != "xno"; then
-		AX_EXT_HAVE_STATIC_LIB(PCAP, DEFAULT_STATIC_LIB_SEARCH_PATHS, pcap libpcap, pcap_open_live)
+		AC_REQUIRE([AX_EXT_HAVE_STATIC_LIB_DETECT])
+		AX_EXT_HAVE_STATIC_LIB(PCAP, ${DEFAULT_STATIC_LIB_SEARCH_PATHS}, pcap libpcap, pcap_open_live)
 		if test "x$PCAP_FOUND" = xyes; then
 			AC_DEFINE([HAVE_PCAP], [1])
 		fi

--- a/build/m4/aircrack_ng_pcre.m4
+++ b/build/m4/aircrack_ng_pcre.m4
@@ -44,7 +44,8 @@ AC_ARG_ENABLE(static-pcre,
     [static_pcre=$enableval], [static_pcre=no])
 
 if test "x$static_pcre" != "xno"; then
-	AX_EXT_HAVE_STATIC_LIB(PCRE, DEFAULT_STATIC_LIB_SEARCH_PATHS, pcre libpcre, pcre_version)
+	AC_REQUIRE([AX_EXT_HAVE_STATIC_LIB_DETECT])
+	AX_EXT_HAVE_STATIC_LIB(PCRE, ${DEFAULT_STATIC_LIB_SEARCH_PATHS}, pcre libpcre, pcre_version)
 	if test "x$PCRE_FOUND" = xyes; then
 		HAVE_PCRE=yes
 	else

--- a/build/m4/aircrack_ng_sqlite.m4
+++ b/build/m4/aircrack_ng_sqlite.m4
@@ -45,7 +45,8 @@ AC_ARG_ENABLE(static-sqlite3,
     [static_sqlite3=$enableval], [static_sqlite3=no])
 
 if test "x$static_sqlite3" != "xno"; then
-	AX_EXT_HAVE_STATIC_LIB(SQLITE3, DEFAULT_STATIC_LIB_SEARCH_PATHS, sqlite3 libsqlite3, sqlite3_open, -lpthread -ldl)
+	AC_REQUIRE([AX_EXT_HAVE_STATIC_LIB_DETECT])
+	AX_EXT_HAVE_STATIC_LIB(SQLITE3, ${DEFAULT_STATIC_LIB_SEARCH_PATHS}, sqlite3 libsqlite3, sqlite3_open, -lpthread -ldl)
 	if test "x$SQLITE3_FOUND" = xyes; then
 		HAVE_SQLITE3=yes
 	fi

--- a/build/m4/ax_lib_sqlite3.m4
+++ b/build/m4/ax_lib_sqlite3.m4
@@ -40,6 +40,7 @@
 
 AC_DEFUN([AX_LIB_SQLITE3],
 [
+    AC_REQUIRE([AX_EXT_HAVE_STATIC_LIB_DETECT])
     AC_ARG_WITH([sqlite3],
         AS_HELP_STRING(
             [--with-sqlite3=@<:@ARG@:>@],
@@ -83,7 +84,7 @@ AC_DEFUN([AX_LIB_SQLITE3],
         AC_MSG_CHECKING([for SQLite3 header])
 
         if test "$ac_sqlite3_path" != ""; then
-            ac_sqlite3_ldflags="-L$ac_sqlite3_path/lib"
+            ac_sqlite3_ldflags="-L$ac_sqlite3_path/${STATIC_LIBDIR_NAME}"
             ac_sqlite3_cppflags="-I$ac_sqlite3_path/include"
             AC_MSG_RESULT([explicitly set; $ac_sqlite3_path])
         else
@@ -92,7 +93,7 @@ AC_DEFUN([AX_LIB_SQLITE3],
                     && test -r "$ac_sqlite3_path_tmp/include/$ac_sqlite3_header"; then
                     ac_sqlite3_path=$ac_sqlite3_path_tmp
                     ac_sqlite3_cppflags="-I$ac_sqlite3_path_tmp/include"
-                    ac_sqlite3_ldflags="-L$ac_sqlite3_path_tmp/lib"
+                    ac_sqlite3_ldflags="-L$ac_sqlite3_path_tmp/${STATIC_LIBDIR_NAME}"
                     AC_MSG_RESULT([found; $ac_sqlite3_path_tmp/include/$ac_sqlite3_header])
                     break;
                 fi


### PR DESCRIPTION
introduce AX_EXT_HAVE_STATIC_LIB_DETECT macro to detect the location of the
lib directories, allow to specify the lib component (lib, lib64) and use the
detected host instead of gcc explicit command.

the change requires converting the DEFAULT_STATIC_LIB_SEARCH_PATHS from m4
macro to environment variable.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>