### PR TITLE
add clang-tidy as an optional linter and run lint via make check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ Makefile
 /cccc.opt
 /.scannerwork
 benchmark*.csv
+*.lint
 /bw-output
 compile_commands.json
 coverage*.info

--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,13 @@ AC_CHECK_LIB([dl], [dlopen], [ LIBS="$LIBS -ldl" ], [:])
 AC_CHECK_LIB([m], [sin], [ LIBS="$LIBS -lm" ], [:])
 
 #
+# Linter, optional
+#
+AC_PATH_PROG([LINTER], [clang-tidy], [true])
+AS_IF([test "x$LINTER" = xtrue],
+    [AC_MSG_WARN([We recommend clang-tidy for developing this package.])])
+
+#
 # Code Coverage Support
 #
 AIRCRACK_NG_CODE_COVERAGE

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -321,5 +321,46 @@ EXTRA_DIST = wpaclean.c \
              session.c \
              session.h
 
+lint_files = $(aircrack_ng_SOURCES) \
+			  $(airdecap_ng_SOURCES) \
+			  $(packetforge_ng_SOURCES) \
+			  $(aireplay_ng_SOURCES) \
+			  $(airodump_ng_SOURCES) \
+			  $(airserv_ng_SOURCES) \
+			  $(airtun_ng_SOURCES) \
+			  $(ivstools_SOURCES) \
+			  $(kstats_SOURCES) \
+			  $(wesside_ng_SOURCES) \
+			  $(easside_ng_SOURCES) \
+			  $(buddy_ng_SOURCES) \
+			  $(besside_ng_SOURCES) \
+			  $(besside_ng_crawler_SOURCES) \
+			  $(makeivs_ng_SOURCES) \
+			  $(airolib_ng_SOURCES) \
+			  $(airbase_ng_SOURCES) \
+			  $(airdecloak_ng_SOURCES) \
+			  $(tkiptun_ng_SOURCES) \
+			  $(wpaclean_SOURCES) \
+			  $(airventriloquist_ng_SOURCES) \
+			  $(libaclib_la_SOURCES) \
+			  $(libcow_la_SOURCES) \
+			  $(libptw_la_SOURCES)
+
+# Make this OK to fail, tee our lint to the file as well.
+LINTER_FLAGS ?= -- -I. $(AM_CPPFLAGS) $(DEFS)
+%.c.lint: %.c
+	- $(LINTER) $? $(LINTER_FLAGS) | tee $@
+
+# Select only C files
+# We have to abuse the auto rule above so that -j works
+lint: $(subst .c,.c.lint, $(filter %.c,$(lint_files)))
+
+.PHONY: lint
+
+check-local: lint
+
+clean-local:
+	rm -f *.lint
+
 
 @CODE_COVERAGE_RULES@


### PR DESCRIPTION
@jbenden you may know a sexier way to implement this. I thought you may like it though!

Most of the lint is noise about unused stores/variables and strcat/strcpy

Some are about memory issues, null pointers, and garbage values.

Original inspiration:
https://stackoverflow.com/questions/29811970/adding-linting-to-autotools-based-build-system/53109982#53109982