### PR TITLE
Change ti_rate from int to int32_t

### DIFF
--- a/src/aircrack-osdep/osdep.h
+++ b/src/aircrack-osdep/osdep.h
@@ -78,7 +78,7 @@
 
 struct tx_info
 {
-	unsigned int ti_rate;
+	unsigned int32_t ti_rate;
 };
 
 struct rx_info


### PR DESCRIPTION
`sizeof(int)` varies on different compilers with different platforms, causing the size of a `tx_info` struct to vary. Even though `tx_info` isn't used, it's size still matters, because airserv-ng uses the struct. If one version of aircrack is compiled with 16 bit ints, and it connects to airserv-ng compiled with 32 bit ints, [writing packets](https://github.com/aircrack-ng/aircrack-ng/blob/master/src/airserv-ng.c#L322) breaks.