### PR TITLE
Fix wpaclean to write all, and not only the last captured handshake to the output file.

### DIFF
--- a/src/wpaclean.c
+++ b/src/wpaclean.c
@@ -149,7 +149,10 @@ static void save_network(const struct timespec * ts, const struct network * n)
 
 	int i;
 
-	_outfd = open_pcap(_outfilename);
+	if (_outfd == 0)
+	{
+		_outfd = open_pcap(_outfilename);
+	}
 	write_pcap(_outfd, ts, n->n_beacon, n->n_beaconlen);
 
 	for (i = 0; i < 4; i++)


### PR DESCRIPTION


In save_network(), open_pcap() is called for each detected network
in the input capture files. open_pcap() truncates the existing
file, and starts from zero with each network it finds.
So only call open_pcap() on the first network/handshake it detects,
so that subsequtent handshakes are added to the output capture file.