### PR TITLE
autoconf: fix openssl static library order

### DIFF
--- a/build/m4/ax_check_openssl.m4
+++ b/build/m4/ax_check_openssl.m4
@@ -50,7 +50,7 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
             esac
         ], [
             AC_CHECK_LIB([crypto], [OPENSSL_init], [
-                OPENSSL_LIBS="-lcrypto -lssl"
+                OPENSSL_LIBS="-lssl -lcrypto"
                 OPENSSL_LDFLAGS=""
 
                 AC_CHECK_HEADERS([openssl/crypto.h], [


### PR DESCRIPTION
if installed only as static libs, the order of the link command line matters,
and -lssl requires symbols which -lcrypto provides.
the second spot in this file had it right.
(it doesn't matter with dynamic libs due to DT_DYN tab containing all
required library names per shared object).