### PR TITLE
Fix timing jump from [08:38:36] to [09:39:18] within 40 seconds.

### DIFF
--- a/src/aircrack-ng/aircrack-ng.c
+++ b/src/aircrack-ng/aircrack-ng.c
@@ -3639,12 +3639,9 @@ static void show_wpa_stats(char * key,
 	delta = chrono(&t_begin, 0);
 	if (delta <= FLT_EPSILON) goto __out;
 
-	et_s = (int) lrintf(fmodf(delta, 59.f));
-	et_m = (int) lrintf(fmodf(((delta - et_s) / 60.0), 59.0f));
-	if (delta >= 60.f * 60.f)
-		et_h = (int) lrintf((delta - et_s - et_m) / (60.f * 60.f));
-	else
-		et_h = 0;
+	et_s = (int) (fmodf(delta, 60.f));
+	et_m = (int) (fmodf(((delta - et_s) / 60.0), 60.0f));
+	et_h = (int) (delta / (60.f * 60.f));
 
 	ALLEGE(pthread_mutex_lock(&mx_nb) == 0);
 	cur_nb_kprev = nb_kprev;


### PR DESCRIPTION
lrintf() function doesn't set its rounding direction,
resulting in 0.501 hour or so equal to 1 hour, not 0 hour.
E.g: [00:29:59] jumps to [01:00:01]