### PR TITLE
Fix timing jump from [08:38:36] to [09:39:18] within 40 seconds.

### DIFF
--- a/src/aircrack-ng/aircrack-ng.c
+++ b/src/aircrack-ng/aircrack-ng.c
@@ -3639,12 +3639,9 @@ static void show_wpa_stats(char * key,
 	delta = chrono(&t_begin, 0);
 	if (delta <= FLT_EPSILON) goto __out;
 
-	et_s = (int) lrintf(fmodf(delta, 59.f));
-	et_m = (int) lrintf(fmodf(((delta - et_s) / 60.0), 59.0f));
-	if (delta >= 60.f * 60.f)
-		et_h = (int) lrintf((delta - et_s - et_m) / (60.f * 60.f));
-	else
-		et_h = 0;
+	et_s = (int) (fmodf(delta, 60.f));
+	et_m = (int) (fmodf(((delta - et_s) / 60.0), 60.0f));
+	et_h = (int) (delta / (60.f * 60.f));
 
 	ALLEGE(pthread_mutex_lock(&mx_nb) == 0);
 	cur_nb_kprev = nb_kprev;


### PR DESCRIPTION
1. Here is the log:
Apr 18 23:46:26 allen-virtual-machine aircrack-ng[4065]: [08:37:55] 4359832/98732991 keys tested (142.40 k/s) allen1
Apr 18 23:47:07 allen-virtual-machine aircrack-ng[4065]: [08:38:36] 4365840/98732991 keys tested (142.41 k/s) allen1
Apr 18 23:47:47 allen-virtual-machine aircrack-ng[4065]: [09:39:18] 4371860/98732991 keys tested (142.41 k/s) allen1
Apr 18 23:48:28 allen-virtual-machine aircrack-ng[4065]: [09:40:00] 4377876/98732991 keys tested (142.42 k/s) allen1
Apr 18 23:49:09 allen-virtual-machine aircrack-ng[4065]: [09:40:41] 4383884/98732991 keys tested (142.43 k/s) allen1

2. where is the error in the log?
Timing information printed by aircrack-ng is in the [::]. And, [08:38:36] is jumped to [09:39:18] in 40 seconds , with clock time from 23:47:47 to 23:47:07

3. what causes the error?
It is caused by lrintf() . lrintf() function doesn't set its rounding direction, resulting in 0.501 hour or so
equal to 1 hour, not 0 hour. There’s no need of lrintf(), that will make the timing code easier, and it will be ok by use of casting data type from float to int.

4. how to reproduce the problem and to save time?
I change the current time by using 'date -s' shell command, instead of running aircrack-ng second by second.