### PR TITLE
build/m4/ax_check_openssl.m4: prefer pkg-config over AC_CHECK_LIB

### DIFF
--- a/build/m4/ax_check_openssl.m4
+++ b/build/m4/ax_check_openssl.m4
@@ -49,28 +49,28 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
               ;;
             esac
         ], [
-            AC_CHECK_LIB([crypto], [OPENSSL_init], [
-                OPENSSL_LIBS="-lssl -lcrypto"
-                OPENSSL_LDFLAGS=""
-
-                AC_CHECK_HEADERS([openssl/crypto.h], [
-                    OPENSSL_INCLUDES=""
+            # if pkg-config is installed and openssl has installed a .pc file,
+            # then use that information and don't search ssldirs
+            AC_CHECK_TOOL([PKG_CONFIG], [pkg-config])
+            if test x"$PKG_CONFIG" != x""; then
+                OPENSSL_LDFLAGS=`$PKG_CONFIG openssl --libs-only-L 2>/dev/null`
+                if test $? = 0; then
+                    OPENSSL_LIBS=`$PKG_CONFIG openssl --libs-only-l 2>/dev/null`
+                    OPENSSL_INCLUDES=`$PKG_CONFIG openssl --cflags-only-I 2>/dev/null`
                     found=true
-                ])
-            ])
+                fi
+            fi
 
             if ! $found; then
-                # if pkg-config is installed and openssl has installed a .pc file,
-                # then use that information and don't search ssldirs
-                AC_CHECK_TOOL([PKG_CONFIG], [pkg-config])
-                if test x"$PKG_CONFIG" != x""; then
-                    OPENSSL_LDFLAGS=`$PKG_CONFIG openssl --libs-only-L 2>/dev/null`
-                    if test $? = 0; then
-                        OPENSSL_LIBS=`$PKG_CONFIG openssl --libs-only-l 2>/dev/null`
-                        OPENSSL_INCLUDES=`$PKG_CONFIG openssl --cflags-only-I 2>/dev/null`
+                AC_CHECK_LIB([crypto], [OPENSSL_init], [
+                    OPENSSL_LIBS="-lssl -lcrypto"
+                    OPENSSL_LDFLAGS=""
+
+                    AC_CHECK_HEADERS([openssl/crypto.h], [
+                        OPENSSL_INCLUDES=""
                         found=true
-                    fi
-                fi
+                    ])
+                ])
             fi
 
             # no such luck; use some default ssldirs


### PR DESCRIPTION
When searching for openssl, pkg-config should be preferred over
AC_CHECK_LIB to retrieve openssl static dependencies and avoid the
following build failure on architecture that links with -latomic such as
sparc v8 32bits:

```
configure:13813: checking whether compiling and linking against OpenSSL works
Trying link with OPENSSL_LDFLAGS=; OPENSSL_LIBS=-lssl -lcrypto; OPENSSL_INCLUDES=
configure:13835: /home/fabrice/buildroot/output/host/bin/sparc-linux-gcc -o conftest -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -static  -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -static  conftest.c -lssl -lcrypto -L/home/fabrice/buildroot/output/host/sparc-buildroot-linux-uclibc/sysroot/usr/bin/../../../../sparc-buildroot-linux-uclibc/sysroot/usr/lib/.libs -lnl-genl-3 -lnl-3  >&5
/home/fabrice/buildroot/output/host/opt/ext-toolchain/bin/../lib/gcc/sparc-buildroot-linux-uclibc/8.3.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: /home/fabrice/buildroot/output/host/sparc-buildroot-linux-uclibc/sysroot/usr/lib/libssl.a(ssl_lib.o): in function `CRYPTO_UP_REF.isra.6':
ssl_lib.c:(.text+0x3c8): undefined reference to `__atomic_fetch_add_4'
```
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>