### PR TITLE
Update Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,18 @@ os:
     - linux
     - osx
 
+#need due bug on homebrew see 
+#https://changelog.travis-ci.com/xcode-11-3-1-xcode-11-2-1-xcode-11-1-and-xcode11-images-updated-142286
+osx_image: xcode11.4
+
 language: c
 
-sudo: true
-
 before_install:
-    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then (brew update && brew install cmocka openssl libgcrypt sqlite3 libpcap pcre || echo -e "\e[1;31m Skipping Homebrew... \e[0m"); fi
-    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then echo -e "\e[1;31m Skipping Code Coverage... \e[0m"; else pip install --user cpp-coveralls; fi
+    #ccache hacks. see https://github.com/travis-ci/travis-ci/issues/5383 
+    #Install ccache on osx
+    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
+    #Fix ccache for clang
+    - if [ "$CC" = "clang" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then export CFLAGS="-Qunused-arguments"; else CFLAGS=""; fi
 
 addons:
   apt:
@@ -25,7 +30,19 @@ addons:
       - libcmocka0
       - libcmocka-dev
       - libhwloc-dev
+      - clang-format-3.8
+  homebrew:
+    packages:
+      - ccache
+      - cmocka
+      - libpcap
+      - libgcrypt
+      - openssl
+      - pcre
+      - sqlite3
 
+    #update: true
+ 
 compiler:
   - gcc
   - clang
@@ -35,3 +52,5 @@ script:
     - ./build/travis-format.sh GCrypt "Building with GCrypt..." ./build/gcrypt.sh
     - ./build/travis-format.sh OpenSSL "Building with OpenSSL..." ./build/openssl.sh
     - ./build/travis-format.sh Dist "Creating a dist tarball and then building from it..." ./build/dist_check.sh
+
+cache: ccache

--- a/build/travis-formatting.sh
+++ b/build/travis-formatting.sh
@@ -14,11 +14,6 @@ case "$CC" in
     clang*|llvm*) exit 0;;
 esac
 
-sudo add-apt-repository -y 'deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.8 main'
-wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-get update -qq
-sudo apt-get install --allow-unauthenticated -y -qq clang-format-3.8
-
 # check formatting matches clang-format-3.8. Since newer versions can have
 # changes in formatting even without any rule changes, we have to fix on a
 # single version.


### PR DESCRIPTION
- OSX custom code replaced with homebrew addon.
- Removed packages that already exist on current linux and OSX image
- Enabled ccache.

I'm not sure if Travis CI is really used, I have several questions before set this PR as ready to merge.

1. Code looks outdated, maybe the original code was designed for pangolin, as I see at:
https://github.com/aircrack-ng/aircrack-ng/blob/master/build/travis-formatting.sh#L17
There is no `distro` tag set to is using Xenial. ¿can I update to Bionic?

2. OSX image is using xcode9.4 that has one bug on brew addon. The bug is fixed on xcode11. ¿can I update to xcode11? I'm not familiar with OSX.

 3. I fact in this PR the OSX build **not install** cmocka and libpcap, and looks like is working fine. ¿this dependencies are needed?
 

