### PR TITLE
airodump-ng: add manufacturer column to the clients list

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -4045,10 +4045,18 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 
 	if (lopt.show_sta)
 	{
-		strlcpy(strbuf,
-				" BSSID              STATION "
-				"           PWR   Rate    Lost    Frames  Notes  Probes",
-				sizeof(strbuf));
+		if (lopt.show_manufacturer)
+			strlcpy(strbuf,
+					" BSSID              STATION "
+					"           PWR   Rate    Lost    Frames  Notes  "
+					"Manufacturer                   "
+					" Probes",
+					sizeof(strbuf));
+		else
+			strlcpy(strbuf,
+					" BSSID              STATION "
+					"           PWR   Rate    Lost    Frames  Notes  Probes",
+					sizeof(strbuf));
 		strbuf[ws_col - 1] = '\0';
 		console_puts(strbuf);
 		CHECK_END_OF_SCREEN();
@@ -4152,6 +4160,19 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 					   (st_cur->wpa.pmkid[0] != 0)
 						   ? "PMKID"
 						   : (st_cur->wpa.state == 7 ? "EAPOL" : ""));
+
+				if (lopt.show_manufacturer)
+				{
+					if (st_cur->manuf == NULL)
+					{
+						st_cur->manuf = get_manufacturer(st_cur->stmac[0],
+														 st_cur->stmac[1],
+														 st_cur->stmac[2]);
+					}
+					if (strstr(st_cur->manuf, "Unknown") == NULL)
+						printf(strlen(st_cur->manuf) > 32 ? "  %s" : "  %-32s",
+							   st_cur->manuf);
+				}
 
 				if (ws_col > (columns_sta - 6))
 				{


### PR DESCRIPTION
Aircrack's airodump utility has an option --manufacturer:

    --manufacturer : Display manufacturer from IEEE OUI list

Currently, it shows only AP (`BSSID`) manufacturer, but will be come in handy to see also connected stations manufacturer.

For example, sometimes due pentesting purposes is necessary to view stations manufacturer and to not disconnecting all clients from the AP, but only one/two/etc (the most vulnerable from the point of view of Social Engineering).

For example.

Before patching:
```
 BSSID             STATION            PWR    Rate   Lost  Frames Notes Probes
 XX:XX:XX:XX:XX:XX XX:XX:XX:XX:XX:XX -54    0 - 0e  0     1            XXX,XXXXX,XXXXXX
 XX:XX:XX:XX:XX:XX XX:XX:XX:XX:XX:XX -38    0 - 0e  155   43
```
After:
```
 BSSID             STATION            PWR    Rate   Lost  Frames Notes Manufacturer                    Probes
 XX:XX:XX:XX:XX:XX XX:XX:XX:XX:XX:XX -54    0 - 0e  0     1            Hon Hai Precision Ind. Co.,Ltd. XXX,XXXXX,XXXXXX

 XX:XX:XX:XX:XX:XX XX:XX:XX:XX:XX:XX -38    0 - 0e  155   43           Liteon Technology Corporation
 ```

This PR adds manufacturer column to the clients list. It shows STATION's manufacturer.

Kind Regards,
A.