### PR TITLE
fixes double free() reported in #2185

### DIFF
--- a/lib/osdep/linux.c
+++ b/lib/osdep/linux.c
@@ -2245,7 +2245,9 @@ static int do_linux_open(struct wif * wi, char * iface)
 	dev->arptype_in = dev->arptype_out;
 
 	if (iface_malloced) free(iface);
+#ifdef CONFIG_LIBNL
 	if (iwpriv) free(iwpriv);
+#endif
 	if (r_file)
 	{
 		free(r_file);


### PR DESCRIPTION
When `CONFIG_LIBNL` is defined, `iwpriv` is `free()`d in `do_linux_open` and also in `linux_close`.

This fix will prevent the `free()` in `do_linux_open` if CONFIG_LIBNL is not defined, preventing the double free.

This fixes the issue reported in #2185 