### PR TITLE
Fix session saving time

### DIFF
--- a/manpages/aircrack-ng.1.in
+++ b/manpages/aircrack-ng.1.in
@@ -117,7 +117,7 @@ Path to a dictionary file for wpa cracking. Separate filenames with comma when u
 In order to use a dictionary with hexadecimal values, prefix the dictionary with "h:". Each byte in each key must be separated by ':'. When using with WEP, key length should be specified using -n.
 .TP
 .I -N <file> or --new-session <file>
-Create a new cracking session. It allows one to interrupt cracking session and restart at a later time (using -R or --restore-session). Status files are saved every 5 minutes. It does not overwrite existing session file.
+Create a new cracking session. It allows one to interrupt cracking session and restart at a later time (using -R or --restore-session). Status files are saved every 10 minutes. It does not overwrite existing session file.
 .TP
 .I -R <file> or --restore-session <file>
 Restore and continue a previously saved cracking session. This parameter is to be used alone, no other parameter should be specified when starting aircrack-ng (all the required information is in the session file).


### PR DESCRIPTION
Version 1.6 saves every 10 minutes instead of 5 minutes.
This is also documented on the aircrack-ng.org [cracking session](https://aircrack-ng.org/~U%C3%83%C2%85%C3%82%C2%BD%C3%83%C2%A2%C3%A2%C2%82%C2%AC%C3%82%C2%B9%C3%83%C2%83%C3%A2%C2%84%C2%A2+%C3%83%C2%83%C3%85%C2%A1%C3%83%C2%83+K%C3%83%C2%85%C3%A2%C2%80%C2%9C+++%C3%83%C2%83%C3%85%C2%A1Y+[[%C3%83%C2%83%C3%85%C2%93%C3%83%C2%A2%C3%A2%C2%80%C2%9E%C3%82%C2%A2[%C3%83%C2%A2%C3%A2%C2%80%C2%9E%C3%82%C2%A2]%C3%83%C2%83%C3%85%C2%93/doku.php?id=aircrack-ng#cracking_session) website.
