### PR TITLE
fix(aircrack-ng): multiple size definitions

### DIFF
--- a/build/m4/aircrack_ng_largefile.m4
+++ b/build/m4/aircrack_ng_largefile.m4
@@ -37,10 +37,49 @@ dnl
 dnl If you delete this exception statement from all source files in the
 dnl program, then also delete it here.
 
-AC_DEFUN([AIRCRACK_NG_LARGEFILE], [
-AX_REQUIRE_DEFINED([AC_SYS_LARGEFILE])[]dnl
-
+AC_DEFUN([_AIRCRACK_NG_LARGEFILE_TEST], [
+AC_LANG_PUSH([C++])
+AC_CHECK_SIZEOF([off_t])
+AC_SYS_LONG_FILE_NAMES
 AC_SYS_LARGEFILE
+AC_FUNC_FSEEKO
+AC_CHECK_SIZEOF([off_t])
+AC_LANG_POP([C++])
+
+ac_cv_sizeof_off_t_cpp=$ac_cv_sizeof_off_t
+unset ac_cv_sizeof_off_t
+
+AC_LANG_PUSH([C])
+AC_CHECK_SIZEOF([off_t])
+AC_SYS_LONG_FILE_NAMES
+AC_SYS_LARGEFILE
+AC_FUNC_FSEEKO
+AC_CHECK_SIZEOF([off_t])
+AC_LANG_POP([C])
+
+ac_cv_sizeof_off_t_c=$ac_cv_sizeof_off_t
+unset ac_cv_sizeof_off_t
+])
+
+AC_DEFUN([AIRCRACK_NG_LARGEFILE], [
+
+_AIRCRACK_NG_LARGEFILE_TEST
+
+AS_IF([test ".$ac_cv_sizeof_off_t_c" != ".$ac_cv_sizeof_off_t_cpp"], [
+    AS_IF([test $ac_cv_sizeof_off_t_cpp -eq 4], [
+        AC_DEFINE([_FILE_OFFSET_BITS], [64], [Define this if 64-bit file access requires this define to be present])
+        CXXFLAGS="$CXXFLAGS -D_FILE_OFFSET_BITS=64"
+    ])
+    AS_IF([test $ac_cv_sizeof_off_t_c -eq 4], [
+        AC_DEFINE([_FILE_OFFSET_BITS], [64], [Define this if 64-bit file access requires this define to be present])
+        CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64"
+    ])
+    unset ac_cv_sizeof_off_t
+    _AIRCRACK_NG_LARGEFILE_TEST
+    AS_IF([test ".$ac_cv_sizeof_off_t_c" != ".$ac_cv_sizeof_off_t_cpp"], [
+        AC_MSG_ERROR([Cannot figure out how to make C and C++ compilers have the same sized off_t.])
+    ])
+])
 
 AS_IF([test ".$ac_cv_sys_file_offset_bits$ac_cv_sys_large_files" != ".nono"], [
     AC_DEFINE([_LARGEFILE64_SOURCE], [1], [Define this if 64-bit file access requires this define to be present])

--- a/include/aircrack-ng/aircrack-ng.h
+++ b/include/aircrack-ng/aircrack-ng.h
@@ -153,7 +153,7 @@ struct options
 	int nbdict; /* current dict number  */
 	int no_stdin; /* if dict == stdin     */
 	int hexdict[MAX_DICTS]; /* if dict in hex       */
-	long long int wordcount; /* Total wordcount for all dicts*/
+	size_t wordcount; /* Total wordcount for all dicts*/
 	struct dictfiles dictidx[MAX_DICTS]; /* Dictionary structure		*/
 	int totaldicts; /* total loaded dictionaries	*/
 	int dictfinish; /* finished processing all dicts*/

--- a/src/aircrack-ng/linecount.cpp
+++ b/src/aircrack-ng/linecount.cpp
@@ -76,7 +76,7 @@ static size_t FileRead(istream & is, vector<char> & buff)
 	return is.gcount();
 }
 
-unsigned int linecount(const char * file, off_t offset, size_t offsetmax)
+size_t linecount(const char * file, off_t offset, size_t maxblocks)
 {
 	const size_t SZ = READBUF_BLKSIZE;
 	std::vector<char> buff(SZ);
@@ -85,9 +85,9 @@ unsigned int linecount(const char * file, off_t offset, size_t offsetmax)
 	size_t cc = 0;
 	size_t blkcnt = 1;
 
-	if (offsetmax <= 0U) return 0;
+	if (maxblocks <= size_t(0)) return 0;
 
-	if (offset) ifs.seekg(offset, ifs.beg);
+	if (offset > 0) ifs.seekg(offset, ifs.beg);
 
 	while ((cc = FileRead(ifs, buff)) > 0)
 	{
@@ -96,7 +96,7 @@ unsigned int linecount(const char * file, off_t offset, size_t offsetmax)
 
 		n += nb_read;
 
-		if (blkcnt >= offsetmax) return n;
+		if (blkcnt >= maxblocks) return n;
 
 		blkcnt++;
 	}

--- a/src/aircrack-ng/linecount.h
+++ b/src/aircrack-ng/linecount.h
@@ -39,8 +39,9 @@
 #define EXTERNC
 #endif
 
-EXTERNC unsigned int linecount(const char * file, off_t offset, size_t blksize);
+EXTERNC size_t linecount(const char * file, off_t offset, size_t maxblocks);
 
 #define READBUF_BLKSIZE (1024 * 1024 * 3)
+#define READBUF_MAX_BLOCKS 32U
 
 #endif /* LINECOUNT_H */


### PR DESCRIPTION
- Use the type `size_t` for all large, unsigned values.
- Have Autoconf determine and attempt to fix a size mismatch
  between the C and C++ compilers, for the `off_t` type.
- Moved a magic number to a definition.
- Switch from `fseek` to `fseeko`.

Fixes: #2192 
Signed-off-by: Joseph Benden <joe@benden.us>