### PR TITLE
airgraph-ng, airdrop-ng: add ability to parse ESSIDs containing commas from .csv files

### DIFF
--- a/scripts/airdrop-ng/airdrop/libDumpParse.py
+++ b/scripts/airdrop-ng/airdrop/libDumpParse.py
@@ -4,6 +4,8 @@
 #part of the airdrop-ng project
 from sys import exit as Exit
 
+import re
+
 class airDumpParse:
 	def parser(self,file):
 		"""
@@ -66,10 +68,34 @@ class airDumpParse:
 		dict = {}
 		for entry in devices:
 			ap = {}
+			# NOTE: It is expected a rstripped entry.
+			# WARNING: Splitting the entry on every comma means to split the ESSID too if it contains a comma, resulting in more items than expected.
 			string_list = entry.split(',')
 			#sorry for the clusterfuck but I swear it all makes sense, this is building a dic from our list so we don't have to do position calls later
-			len(string_list)
-			if len(string_list) == 15:
+			if re.match(r'^([^,]+,){9}(\s*[0-9]+\.){3}\s*[0-9]+,',entry): # len(string_list) == 11 (see the WARNING above)
+				ip = string_list[9]
+				essid = re.search(re.escape(ip) + r',(.*)$',entry).group(1)[1:]
+				ap = {"bssid":string_list[0].replace(' ',''),
+					"fts":string_list[1],
+					"lts":string_list[2],
+					"channel":string_list[3].replace(' ',''),
+					"speed":string_list[4],
+					"privacy":string_list[5].replace(' ',''),
+					"power":string_list[6],
+					"beacons":string_list[7],
+					"data":string_list[8],
+					"ip":ip.replace(' ',''),
+					"essid":essid}
+			elif re.match(r'^([^,]+,){11}(\s*[0-9]+\.){3}\s*[0-9]+,',entry): # len(string_list) == 15 (see the WARNING above)
+				essid_length = string_list[12].replace(' ','')
+				# this regex may fail if the entry is malformed, e.g. ID-length > 0 but empty ESSID
+				p = re.match(r'^([^,]+,){13} (.{' + essid_length + '}),(.*)$',entry)
+				if p:
+					essid = p.group(2)
+					key = p.group(3)[1:]
+				else:
+					essid = string_list[13][1:]
+					key = string_list[14][1:]
 				ap = {"bssid":string_list[0].replace(' ',''),
 					"fts":string_list[1],
 					"lts":string_list[2],
@@ -82,21 +108,9 @@ class airDumpParse:
 					"beacons":string_list[9],
 					"iv":string_list[10],
 					"ip":string_list[11],
-					"id":string_list[12],
-					"essid":string_list[13][1:],
-					"key":string_list[14]}
-			elif len(string_list) == 11:
-				ap = {"bssid":string_list[0].replace(' ',''),
-					"fts":string_list[1],
-					"lts":string_list[2],
-					"channel":string_list[3].replace(' ',''),
-					"speed":string_list[4],
-					"privacy":string_list[5].replace(' ',''),
-					"power":string_list[6],
-					"beacons":string_list[7],
-					"data":string_list[8],
-					"ip":string_list[9],
-					"essid":string_list[10][1:]}
+					"id":essid_length,
+					"essid":essid,
+					"key":key}
 			if len(ap) != 0:
 				dict[string_list[0]] = ap
 		return dict
@@ -108,6 +122,7 @@ class airDumpParse:
 		dict = {}
 		for entry in devices:
 			client = {}
+			# WARNING: Splitting the entry on every comma means to split the ESSID too if it contains a comma, resulting in more items than expected.
 			string_list = entry.split(',')
 			if len(string_list) >= 7:
 				client = {"station":string_list[0].replace(' ',''),
@@ -116,7 +131,7 @@ class airDumpParse:
 					"power":string_list[3],
 					"packets":string_list[4],
 					"bssid":string_list[5].replace(' ',''),
-					"probe":string_list[6:][0:]}
+					"probe":string_list[6:][0:]} # ESSIDs cannot be split faithfully if any contains a comma (see the WARNING above)
 			if len(client) != 0:
 				dict[string_list[0]] = client
 		return dict

--- a/scripts/airgraph-ng/airgraphviz/libDumpParse.py
+++ b/scripts/airgraph-ng/airgraphviz/libDumpParse.py
@@ -124,16 +124,35 @@ class airDumpParse:
         dict = {}
         for entry in devices:
             client = {}
+            # NOTE: It is expected a rstripped entry.
             # WARNING: Splitting the entry on every comma means to split the ESSID too if it contains a comma, resulting in more items than expected.
             string_list = entry.split(',')
             if len(string_list) >= 7:
+                probe_list = []
+                p = re.match(r'^([^,]+,){6}(.*)$',entry).group(2)
+                while p:
+                    # expect essid_length,essid_string[,...]
+                    essid_length = re.match(r'^([0-9]{1,2}),',p)
+                    if not essid_length:
+                        # this may happen if the entry is malformed or incompatible
+                        probe_list = string_list[6:][0:]
+                        break
+                    essid_length = essid_length.group(1)
+                    l = len(essid_length)
+                    n = int(essid_length)
+                    if n > 32:
+                        # this may happen if the entry is malformed or incompatible
+                        probe_list = string_list[6:][0:]
+                        break
+                    probe_list.append(p[l+1:l+1+n])
+                    p = p[l+2+n:]
                 client = {"station":string_list[0].replace(' ',''),
                     "fts":string_list[1],
                     "lts":string_list[2],
                     "power":string_list[3],
                     "packets":string_list[4],
                     "bssid":string_list[5].replace(' ',''),
-                    "probe":string_list[6:][0:]} # ESSIDs cannot be split faithfully if any contains a comma (see the WARNING above)
+                    "probe":probe_list} # ESSIDs cannot be split faithfully if any contains a comma (see the WARNING above)
             if len(client) != 0:
                 dict[string_list[0]] = client
         return dict

--- a/scripts/airgraph-ng/test/test-2.txt
+++ b/scripts/airgraph-ng/test/test-2.txt
@@ -1,0 +1,11 @@
+
+BSSID, First time seen, Last time seen, channel, Speed, Privacy, Cipher, Authentication, Power, # beacons, # IV, LAN IP, ID-length, ESSID, Key
+AB:FF:C2:3D:B1:B6, 2020-12-24 05:45:02, 2020-12-25 05:45:14,  6,  -1, WPA, ,   , -57,        0,        4,   0.  0.  0.  0,   0, , 
+5E:E8:C9:26:AB:DF, 2020-12-24 05:45:09, 2020-12-11 05:45:15,  2, 130, WPA2, CCMP, PSK, -78,       11,        0,   0.  0.  0.  0,  4, test, 
+54:79:8A:BB:20:73, 2020-12-24 05:45:10, 2020-12-25 05:45:16,  9, 130, WPA2, CCMP, PSK, -21,       10,        0,   0.  0.  0.  0,  14, this is, my ap, 
+
+Station MAC, First time seen, Last time seen, Power, # packets, BSSID, Probed ESSIDs
+8A:35:B7:9A:DD:ED, 2020-12-24 05:45:07, 2020-12-25 05:45:08, -81,        2, (not associated) ,
+58:78:DB:FF:5E:82, 2020-12-24 05:45:09, 2020-12-25 05:45:09, -43,        3, 5E:E8:C9:26:AB:DF,
+83:EF:35:A2:CB:5D, 2020-12-24 05:45:12, 2020-12-25 05:45:11, -83,        1, (not associated) ,second ap
+5E:35:72:DA:45:18, 2020-12-24 05:45:16, 2020-12-25 05:45:15, -83,        1, 54:79:8A:BB:20:73,17,name with , comma,9,second ap

--- a/src/airodump-ng/dump_write.c
+++ b/src/airodump-ng/dump_write.c
@@ -381,12 +381,12 @@ int dump_write_csv(struct AP_info * ap_1st,
 
 			if (probes_written == 0)
 			{
-				fprintf(opt.f_txt, "%s", temp);
+				fprintf(opt.f_txt, "%d,%s", st_cur->ssid_length[i], temp);
 				probes_written = 1;
 			}
 			else
 			{
-				fprintf(opt.f_txt, ",%s", temp);
+				fprintf(opt.f_txt, ",%d,%s", st_cur->ssid_length[i], temp);
 			}
 
 			free(temp);


### PR DESCRIPTION
Hello,

Here I propose some amendments to allow `airgraph-ng` and `airdrop-ng` to parse ESSIDs containing commas from .csv files.

### Summary of bugs found
- `airgraph-ng ... -g CAPR`: entries with an ESSID containing commas in its name being discarded.
- `airgraph-ng ... -g CPG`: _Probed ESSIDs_ are truncated when their name contains commas.

See bottom about the [dump-01.txt](https://github.com/aircrack-ng/aircrack-ng/files/5742324/dump-01.txt) test file (aka `dump-01.csv`).

### Description
Calling `airgraph-ng ... -g CAPR` I could see **entries with an ESSID containing commas in its name being discarded**. This is due to requirements/processing in `airgraphviz/libDumpParse.py` (which are in `airdrop/libDumpParse.py` too):
1. The entry with the offending ESSID is read from the _csv-comma-separated_ file;
2. the read entry is then comma-split (`string_list = entry.split(',')`);
3. the number of fields are expected to be 15 or 11 (`if len(string_list) == 15` or `if len(string_list) == 11`);
4. an ESSID containing commas may exceed the number of expected fields or even give corrupted values (think of an entry of 11 fields, where the ESSID contains enough commas to produce 15 fields when it is comma-split, the resulting 15-fields holds corrupted values).

See also #1707 as reference (the author commented about a [cap-01.csv](https://github.com/aircrack-ng/trac-attachments/blob/master/1707/20161206-140246_047-cap-01.csv) comma-related problem...).

There's also a problem calling `airgraph-ng ... -g CPG`. **The _Probed ESSIDs_ are truncated when their name contains commas**. This is due to `string_list = entry.split(',')`. Since probed ESSID names are comma separated, you could easily see how a name containing commas is split (like **this is, my ap** is split into **this is** and **my ap**).

### Solution
I made some changes to `{airgraphviz,airdrop}/libDumpParse.py` and `airodump-ng/dump_write.c` to address the problems described above. In the former there's some regex used to determine the ESSID position in the entry, and in the latter each ESSID probe wrote in the .csv file (aka _Probed ESSIDs_) is preceded by its length. The ESSID length is used to grab the whole ESSID name without exception (there's also a fallback on `entry.split(',')` fields for .csv files that are in the old or wrong format):
- **this is, my ap** ESSID name should not be discarded when producing a CAPR.
- **name with , comma** ESSID probe should not be truncated when producing a CPG.
- AP entries may end with the previous format "**lan_ip, essid**" (one space after the comma).
- AP entries may end with the current format "**essid_length, essid, key**" (one space after the comma).
- _Probed ESSIDs_ should follow the **NEW FORMAT** "**essid_length,essid[,...]**" (no spaces after the comma).

### Tests
The file [dump-01.txt](https://github.com/aircrack-ng/aircrack-ng/files/5742324/dump-01.txt) is conceived to test the amendments.

PS: I renamed `dump-01.csv` to `dump-01.txt`, because .csv files cannot currently be attached to posts.

```
$ airgraph-ng -i dump-01.txt -o dump-01-cpg.png -g CPG
$ airgraph-ng -i dump-01.txt -o dump-01-capr.png -g CAPR
```

Let me know what you think.

Thanks!