### PR TITLE
airodump-ng: fix dropping of Management frames with zeroed timestamp

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -1251,7 +1251,8 @@ static int dump_add_packet(unsigned char * h80211,
 
 	/* if it's a LLC null packet, just forget it (may change in the future) */
 
-	if (caplen > 28)
+	if (((h80211[0] & IEEE80211_FC0_TYPE_MASK) == IEEE80211_FC0_TYPE_DATA)
+		&& (caplen > 28))
 		if (memcmp(h80211 + 24, llcnull, 4) == 0) return (0);
 
 	/* grab the sequence number */


### PR DESCRIPTION
Management frames like Beacons and Probe Responses that have a zeroed timestamp in their Fixed Parameters are wrongfully dropped. 
This PR fixes this by making sure
- only frames of type Data will be checked for Null LLC and dropped if necessary,
- non-Data frames having zeroed fields at the respective position will be processed as expected.

This PR fixes #2237
A test case is included in linked issue.