### PR TITLE
added Wi-Fi 6E 6GHz channels

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -5701,9 +5701,9 @@ static int detect_frequencies(struct wif * wi)
 		}
 	}
 
-	// again for 5GHz channels
+	// again for 5GHz & 6GHz channels
 	start_freq = 4800;
-	end_freq = 6000;
+	end_freq = 7115;
 	for (freq = start_freq; freq <= end_freq; freq += 5)
 	{
 		if (wi_set_freq(wi, freq) == 0)


### PR DESCRIPTION
Can be used to capture 6GHz using Intel AX210 as:
sudo airmon-ng check kill
sudo airmon-ng start wlan1
sudo airodump-ng wlan1mon -w 6E_test -C 6115

is tested and working in:
Ubuntu 20.04.3 LTS
Linux Kernel 5.15.0-051500-generic