### PR TITLE
airodump-ng: look for oui.txt in /usr/share/hwdata

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -102,6 +102,7 @@ static const char * OUI_PATHS[]
 	   "/usr/share/aircrack-ng/airodump-ng-oui.txt",
 	   "/var/lib/misc/oui.txt",
 	   "/usr/share/misc/oui.txt",
+	   "/usr/share/hwdata/oui.txt",
 	   "/var/lib/ieee-data/oui.txt",
 	   "/usr/share/ieee-data/oui.txt",
 	   "/etc/manuf/oui.txt",


### PR DESCRIPTION
This location is used by the hwdata package on various distros.

https://github.com/vcrhonek/hwdata