### PR TITLE
Back ticks removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Below are instructions for installing the basic requirements to build
 
 #### Arch Linux
 
-    sudo pacman -Sy base-devel libnl openssl ethtool util-linux zlib libpcap sqlite pcre hwloc cmocka hostapd wpa_supplicant tcpdump screen iw usbutils pciutils`
+    sudo pacman -Sy base-devel libnl openssl ethtool util-linux zlib libpcap sqlite pcre hwloc cmocka hostapd wpa_supplicant tcpdump screen iw usbutils pciutils
 
 #### Debian/Ubuntu
 


### PR DESCRIPTION
Hey there,

Removed the backticks from the arch Linux install command. Although nothing wrong will happen because of the backticks just in case noobs copy-paste it.

Thank you