### PR TITLE
lib/crypto/crypto.c: fx build with libressl >= 3.5.0

### DIFF
--- a/lib/crypto/crypto.c
+++ b/lib/crypto/crypto.c
@@ -196,7 +196,7 @@ void calc_mic(struct AP_info * ap,
 	int i;
 	unsigned char pke[100];
 #if defined(USE_GCRYPT) || OPENSSL_VERSION_NUMBER < 0x10100000L                \
-	|| defined(LIBRESSL_VERSION_NUMBER)
+	|| (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x30500000L)
 #define HMAC_USE_NO_PTR
 #endif
 


### PR DESCRIPTION
Fix the following build failure with libressl >= 3.5.0:

```
lib/crypto/crypto.c: In function 'calc_mic':
lib/crypto/crypto.c:203:2: error: variable 'ctx' has initializer but incomplete type
  203 |  HMAC_CTX ctx = {0};
      |  ^~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/d8444dada84a54205273ac627d3e4f4692a55364

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>