### PR TITLE
airmon-ng: avoid direct call of systemctl command

### DIFF
--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -1168,10 +1168,11 @@ scanProcesses() {
 
 	if [ "${1}" = "kill" ]; then
     if [ -x "$(command -v systemctl 2>&1)" ]; then
+        systemctlcmd="$(command -v systemctl 2>&1)"
 		  for service in network-manager NetworkManager avahi-daemon wicd; do
-        if systemctl status "${service}" > /dev/null 2>&1; then
+        if ${systemctlcmd} status "${service}" > /dev/null 2>&1; then
           killservice=1
-          until systemctl stop "${service}" 2> /dev/null > /dev/null; do
+          until ${systemctlcmd} stop "${service}" 2> /dev/null > /dev/null; do
             killservice=$((killservice + 1))
             if [ ${killservice} -gt 5 ]; then
               printf "Failed to stop %s, please stop it on your own.\n" "${service}"


### PR DESCRIPTION
Commit f94a3fe3 introduced systemd support additionally to SystemV. However,
this caused the additional dependency on systemctl executable which is not
desired in some cases. This commit puts it inside a variable which tricks
requirements calculation scripts (if such are used) to ignore systemd.