### PR TITLE
fix: failing build on s390x

### DIFF
--- a/lib/libac/support/common.c
+++ b/lib/libac/support/common.c
@@ -338,9 +338,7 @@ int get_nb_cpus(void)
 #elif defined(__linux__)
 	char *s, *pos;
 	FILE * f;
-	// Reading /proc/cpuinfo is more reliable on current CPUs,
-	// so put it first and try the old method if this one fails
-	f = fopen("/proc/cpuinfo", "r");
+	f = fopen("/proc/stat", "r");
 
 	if (f != NULL)
 	{
@@ -348,29 +346,17 @@ int get_nb_cpus(void)
 
 		if (s != NULL)
 		{
-			// Get the latest value of "processor" element
-			// and increment it by 1 and it that value
-			// will be the number of CPU.
-			number = -2;
+			number = 0;
 
 			while (fgets(s, 80, f) != NULL)
 			{
-				pos = strstr(s, "processor");
-
-				if (pos == s)
+				pos = strstr(s, "cpu");
+				if (pos != NULL && pos + 3 <= s + 81)
 				{
-					pos = strchr(s, ':');
-
-					if (pos != NULL)
-					{
-						int tmp_number = atoi(pos + 1);
-						if (tmp_number >= 0 && tmp_number <= 1024)
-							number = tmp_number;
-					}
+					if (isdigit(*(pos + 3)) != 0) ++number;
 				}
 			}
 
-			++number;
 			free(s);
 		}
 

--- a/src/aircrack-ng/aircrack-ng.c
+++ b/src/aircrack-ng/aircrack-ng.c
@@ -2278,6 +2278,8 @@ static THREAD_ENTRY(packet_reader_thread)
 			{
 				pkh.caplen = ___my_swab32(pkh.caplen);
 				pkh.len = ___my_swab32(pkh.len);
+				pkh.tv_sec = ___my_swab32(pkh.tv_sec);
+				pkh.tv_usec = ___my_swab32(pkh.tv_usec);
 			}
 
 			if (pkh.caplen <= 0 || pkh.caplen > 65535)


### PR DESCRIPTION
- Use `/proc/stat` and not `/proc/cpuinfo` for CPU count.
- Add missed swab of timestamp.

Fixes: #2324
Reviewed-by: samueloph
Signed-off-by: Joseph Benden <joe@benden.us>