### PR TITLE
hostapd-pwe: fix -r option

### DIFF
--- a/patches/wpe/hostapd-wpe/hostapd-2.10-wpe.patch
+++ b/patches/wpe/hostapd-wpe/hostapd-2.10-wpe.patch
@@ -3443,7 +3443,7 @@ diff '--color=auto' -rupN hostapd-2.10/hostapd/main.c hostapd-2.10-wpe/hostapd/m
  
  	for (;;) {
 -		c = getopt(argc, argv, "b:Bde:f:hi:KP:sSTtu:vg:G:");
-+		c = getopt(argc, argv, "b:Bde:f:hi:KP:sSTtu:vg:G:kcs");
++		c = getopt(argc, argv, "b:Bde:f:hi:KP:sSTtu:vg:G:kcr");
  		if (c < 0)
  			break;
  		switch (c) {


### PR DESCRIPTION
The `-r` option wasn't working because it was configured as `s` in getopt.

The rest of the argument handling assumes the option to be `r`.