### PR TITLE
airdecloak-ng: fix typos and indentation in usage info

### DIFF
--- a/src/airdecloak-ng/airdecloak-ng.c
+++ b/src/airdecloak-ng/airdecloak-ng.c
@@ -1532,17 +1532,17 @@ static void usage(void)
 		"and\n"
 		"                                 consecutive sequence number "
 		"(filtering is\n"
-		"                                  much more precise than using all "
+		"                                 much more precise than using all "
 		"these\n"
-		"                                  filters one by one).\n"
+		"                                 filters one by one).\n"
 		"     --null-packets        : Assume that null packets can be "
 		"cloaked.\n"
-		"     --disable-base_filter : Do not apply base filter.\n"
+		"     --disable-base-filter : Do not apply base filter.\n"
 		//"     --disable-retry       : Disable retry check, don't care about
 		// retry bit.\n"
-		"     --drop-frag           : Drop fragmented packets\n"
+		"     --drop-frag           : Drop fragmented packets.\n"
 		"\n"
-		"     --help                : Displays this usage screen\n"
+		"     --help                : Displays this usage screen.\n"
 		"\n",
 		version_info);
 	free(version_info);


### PR DESCRIPTION
Before:
```bash
$ ./airdecloak-ng --help
...
           signal_dup_consec_sn: Use signal (if available), duplicate and
                                 consecutive sequence number (filtering is
                                  much more precise than using all these
                                  filters one by one).
     --null-packets        : Assume that null packets can be cloaked.
     --disable-base_filter : Do not apply base filter.
     --drop-frag           : Drop fragmented packets

     --help                : Displays this usage screen
```
     
After:
```bash
$ ./airdecloak-ng --help
...
           signal_dup_consec_sn: Use signal (if available), duplicate and
                                 consecutive sequence number (filtering is
                                 much more precise than using all these
                                 filters one by one).
     --null-packets        : Assume that null packets can be cloaked.
     --disable-base-filter : Do not apply base filter.
     --drop-frag           : Drop fragmented packets.

     --help                : Displays this usage screen.
```