### PR TITLE
airdecloak-ng: remove dead code from getopt switch, add default branch to getopt switch

### DIFF
--- a/src/airdecloak-ng/airdecloak-ng.c
+++ b/src/airdecloak-ng/airdecloak-ng.c
@@ -1715,6 +1715,9 @@ int main(int argc, char * argv[])
 			case 'h':
 				usage();
 				exit(EXIT_SUCCESS);
+			default:
+				usage();
+				exit(EXIT_FAILURE);
 		}
 	}
 

--- a/src/airdecloak-ng/airdecloak-ng.c
+++ b/src/airdecloak-ng/airdecloak-ng.c
@@ -1709,15 +1709,12 @@ int main(int argc, char * argv[])
 				_options_disable_retry = 1;
 				printf("'%c' option not yet implemented\n", option);
 				exit(EXIT_SUCCESS);
-				break;
 			case 'e':
 				printf("'%c' option not yet implemented\n", option);
 				exit(EXIT_SUCCESS);
-				break;
 			case 'h':
 				usage();
 				exit(EXIT_SUCCESS);
-				break;
 		}
 	}
 


### PR DESCRIPTION
Removed unnecessary breaks from getopt() switch statement and added default branch so it is consistent with the rest of the code base (I checked a couple of other modules like *airbase-ng.c* and *aircrack-ng.c*).