### PR TITLE
airdecloak-ng: getopt related option improvements (--disable-retry, --null-packets, --filtered)

### DIFF
--- a/src/airdecloak-ng/airdecloak-ng.c
+++ b/src/airdecloak-ng/airdecloak-ng.c
@@ -1705,7 +1705,8 @@ int main(int argc, char * argv[])
 				break;
 			case 'n':
 				_options_assume_null_packets_uncloaked = 1;
-				break;
+				printf("'%c' option not yet implemented\n", option);
+				exit(EXIT_SUCCESS);
 			/*case 'r':
 				_options_disable_retry = 1;
 				printf("'%c' option not yet implemented\n", option);

--- a/src/airdecloak-ng/airdecloak-ng.c
+++ b/src/airdecloak-ng/airdecloak-ng.c
@@ -1502,6 +1502,7 @@ static void usage(void)
 		"   Mandatory:\n"
 		"     -i <file>             : Input capture file\n"
 		"     --ssid <ESSID>        : ESSID of the network to filter\n"
+		"                             (not yet implemented)\n"
 		"        or\n"
 		"     --bssid <BSSID>       : BSSID of the network to filter\n"
 		"\n"
@@ -1537,6 +1538,7 @@ static void usage(void)
 		"                                 filters one by one).\n"
 		"     --null-packets        : Assume that null packets can be "
 		"cloaked.\n"
+		"                             (not yet implemented)\n"
 		"     --disable-base-filter : Do not apply base filter.\n"
 		//"     --disable-retry       : Disable retry check, don't care about
 		// retry bit.\n"

--- a/src/airdecloak-ng/airdecloak-ng.c
+++ b/src/airdecloak-ng/airdecloak-ng.c
@@ -69,7 +69,7 @@ static int _is_wep;
 static unsigned char _bssid[6];
 
 static int _options_drop_fragments = 0;
-static int _options_disable_retry = 0;
+//static int _options_disable_retry = 0;
 static int _options_disable_base_filter = 0;
 static int _options_assume_null_packets_uncloaked = 0;
 
@@ -1704,10 +1704,10 @@ int main(int argc, char * argv[])
 			case 'n':
 				_options_assume_null_packets_uncloaked = 1;
 				break;
-			case 'r':
+			/*case 'r':
 				_options_disable_retry = 1;
 				printf("'%c' option not yet implemented\n", option);
-				exit(EXIT_SUCCESS);
+				exit(EXIT_SUCCESS);*/
 			case 'e':
 				printf("'%c' option not yet implemented\n", option);
 				exit(EXIT_SUCCESS);

--- a/src/airdecloak-ng/airdecloak-ng.c
+++ b/src/airdecloak-ng/airdecloak-ng.c
@@ -1583,6 +1583,7 @@ int main(int argc, char * argv[])
 			   {"help", 0, 0, 'h'},
 			   {"filter", 1, 0, 'f'},
 			   {"filters", 1, 0, 'f'},
+			   {"filtered", 1, 0, 'f'},
 			   {"null-packets", 0, 0, 'n'},
 			   {"null-packet", 0, 0, 'n'},
 			   {"null_packets", 0, 0, 'n'},
@@ -1593,7 +1594,6 @@ int main(int argc, char * argv[])
 			   {"drop-frag", 0, 0, 'd'},
 			   {"input", 1, 0, 'i'},
 			   {"cloaked", 1, 0, 'c'},
-			   {"filtered", 1, 0, 'f'},
 			   {0, 0, 0, 0}};
 
 		option = getopt_long(


### PR DESCRIPTION
Changes:

- --disable-retry is not implemented but only some parts of the related code have been commented out previously. Now this is fixed by commenting out all of the related code.
- getopt long_options have been reordered, so the related options are consecutive now.
- --null-packets option is not implemented yet but in the current implementation the user is not notified. Now a "not
implemented" message is printed and the program exits when the option is supplied.
- --ssid and --null-packets are marked as "not yet implemented" options in the help (usage info) message.

I will update the [wiki](https://www.aircrack-ng.org/doku.php?id=airdecloak-ng) also if this PR is merged.