### PR TITLE
scripts: replace optparse with argparse

### DIFF
--- a/scripts/airdrop-ng/airdrop-ng
+++ b/scripts/airdrop-ng/airdrop-ng
@@ -8,7 +8,7 @@ Airdrop-ng A rule based wireless deauth tool
 a compoent of project lemonwedge
 Written by Thex1le and King_Tuna
 """
-import sys, optparse, re, time, random, os
+import sys, argparse, re, time, random, os
 import pdb
 #update the path with sub directories
 #lib for the libraries and support for the oui.txt file
@@ -940,22 +940,22 @@ if __name__ == "__main__":
     """
     usage()
     
-    parser = optparse.OptionParser("usage: %prog options [-i,-t,-r] -s -p -b -n")  #
-    parser.add_option("-i", "--interface",  dest="card",nargs=1, 
+    parser = argparse.ArgumentParser(description="airdrop-ng is a program used for targeted, rule-based deauthentication of users.")  #
+    parser.add_argument("-i", "--interface",  dest="card",nargs=1, 
                 help="Wireless card in monitor mode to inject from")
-    parser.add_option("-t", "--dump", dest="data", nargs=1 ,
+    parser.add_argument("-t", "--dump", dest="data", nargs=1 ,
                 help="Airodump txt file in CSV format NOT the pcap")
-    parser.add_option("-r", "--rule",dest="rule", nargs=1 ,help="Rule File for matched deauths")
-    parser.add_option("-s", "--sleep",dest="slept",default=0,nargs=1,type="int",help="Time to sleep between sending each packet")
-    parser.add_option("-b", "--debug",dest="debug",action="store_true",default=False,help="Turn on Rule Debugging")
-    parser.add_option("-l", "--logging",dest="log",action="store_true",default=False,help="Enable Logging to a file, if file path not provided airdrop will log to default location")
-    parser.add_option("-n", "--nap",dest="nap",default=0,nargs=1,help="Time to sleep between loops")
+    parser.add_argument("-r", "--rule",dest="rule", nargs=1 ,help="Rule File for matched deauths")
+    parser.add_argument("-s", "--sleep",dest="slept",default=0,nargs=1,type=int,help="Time to sleep between sending each packet")
+    parser.add_argument("-b", "--debug",dest="debug",action="store_true",default=False,help="Turn on Rule Debugging")
+    parser.add_argument("-l", "--logging",dest="log",nargs="?",action="store",default=False,const=True,help="Enable Logging to a file, if file path not provided airdrop will log to default location")
+    parser.add_argument("-n", "--nap",dest="nap",default=0,nargs=1,help="Time to sleep between loops")
 
     if len(sys.argv) <= 1: #check and show help if no arguments are provided at runtime
                 parser.print_help()
                 commandUsage()
                 sys.exit(0)
-    (options, args) = parser.parse_args()
+    args = parser.parse_args()
     #set the program loop value
     
     #************
@@ -970,10 +970,13 @@ if __name__ == "__main__":
     
     
     #start up printing
-    if args == []:
-        message = messages(options.log)
+    if args.log is True or args.log is False:
+        # if -l is supplied without a path --> args.log is True
+        # if -l is not supplied --> args.log is False
+        message = messages(args.log)
     else:
-        message = messages(options.log,args[0])
+        # if -l is supplied with a path --> args.log is the path
+        message = messages(True, args.log)
 
     
     TotalPacket = 0 #total packets tx'd
@@ -1001,15 +1004,15 @@ if __name__ == "__main__":
                 'Unable to find liborcon2.so in /usr/local/lib or /usr/lib , is lorcon2 installed?'])
                 sys.exit(-1)
             """
-            tx = PyLorcon2.Context(options.card)
+            tx = PyLorcon2.Context(args.card[0])
             tx.open_injmon()
         except PyLorcon2.Lorcon2Exception as e:
             message.printMessage(["\n",
-                e,"Interface %s does not exist" %(options.card)])
+                e,"Interface %s does not exist" %(args.card[0])])
             sys.exit(-1)
         except ValueError:
             message.printMessage(["\n",
-                "Interface %s does not exist" %(options.card)])
+                "Interface %s does not exist" %(args.card[0])])
             sys.exit(-1)
         try:
             #populate the oui lookup datatbases
@@ -1029,14 +1032,14 @@ if __name__ == "__main__":
             sys.exit(-1)
         
         #Start the main loop
-        napTime = float(options.nap)
-        Targeting = getTargets(options.rule,options.data,options.debug)
+        napTime = float(args.nap[0])
+        Targeting = getTargets(args.rule[0],args.data[0],args.debug)
         #set zero packet flag to false
         zp = False
         while True:
                 Targeting.run() 
                 if Targeting.targets != None:
-                    rtnPktCount = makeMagic(Targeting.targets,int(options.slept))
+                    rtnPktCount = makeMagic(Targeting.targets,int(args.slept[0]))
                     if rtnPktCount == 0:
                         message.printMessage("Zero Packets were to be sent, Napping for 5 sec to await changes in sniffed data\n")
                         zp = True
@@ -1051,5 +1054,5 @@ if __name__ == "__main__":
 
     except (KeyboardInterrupt, SystemExit):
         message.printMessage(["\nAirdrop-ng will now exit","Sent "+str(TotalPacket)+" Packets",
-            "\nExiting Program, Please take your card "+options.card+" out of monitor mode"])
+            "\nExiting Program, Please take your card "+args.card[0]+" out of monitor mode"])
         sys.exit(0)

--- a/scripts/airgraph-ng/airodump-join
+++ b/scripts/airgraph-ng/airodump-join
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # this script is a total hack it works and I'll clean it up later
-import sys,getopt, optparse, pdb, re
+import sys,getopt, argparse, pdb, re
 def raw_lines(file):
 	try:
 		raw_lines = open(file, "r")
@@ -72,13 +72,19 @@ if  __name__ == "__main__":
 		showBanner()
 		sys.exit(1)
 
-	parser = optparse.OptionParser("usage: %prog [options] arg1 arg2 arg3 .....")
-	parser.add_option("-o", "--output",  dest="output",nargs=1, help="output file to write to")
-	parser.add_option("-i", "--file", dest="filename", nargs=2 ,help="Input files to read data from requires at least two arguments")
+	parser = argparse.ArgumentParser(description="A support tool for airgraph-ng that allows you to join the airodump output files.")
+	parser.add_argument("-o", "--output",  dest="output",nargs=1, help="output file to write to")
+	parser.add_argument("-i", "--file", dest="filename", nargs="*" ,help="Input files to read data from requires at least two arguments")
 	
-	(options, args) = parser.parse_args()
-	filenames = options.filename
-	outfile = options.output
+	args = parser.parse_args()
+	# we need this manual check because argparse does not support requiring 2 or more nargs
+	# the closest we could do is nargs="+" which means 1 or more
+	if len(args.filename) < 2:
+		parser.print_usage()
+		print("airodump-join: error: argument -i/--file: expected at least two arguments")
+		sys.exit(1)
+	filenames = tuple(args.filename)
+	outfile = args.output[0]
 	if outfile == None:
 		print("You must provide a file name to write out to. IE... -o foo.csv\n")
 		showBanner()
@@ -87,8 +93,6 @@ if  __name__ == "__main__":
 		print("You must provide at least two file names to join. IE... -i foo1.csv foo2.csv\n")
 		showBanner()
 		sys.exit(1)
-	for file_name in args:
-		filenames += (file_name,)	
 	return_var = file_pool(filenames)
 	return_var = join_write(return_var,outfile)
 

--- a/scripts/versuck-ng/versuck-ng
+++ b/scripts/versuck-ng/versuck-ng
@@ -9,7 +9,7 @@ key off the internal mac address of your router and
 some basic base 36 math. Sounds like a fine idea to me!
 """
 
-import optparse, sys
+import argparse, sys
 def createKey(essid,bssid):
 	actionOUI = ['0020E0', 
 		'000FB3', 
@@ -47,16 +47,16 @@ def banner():
 	print("#"*16)
 
 if __name__ == "__main__":
-	parser = optparse.OptionParser("usage: %prog options -m -e")
-	parser.add_option("-m", "--mac", dest="mac",nargs=1, help="Mac Address")
-	parser.add_option("-e", "--essid", dest="essid",nargs=1, help="essid")
+	parser = argparse.ArgumentParser(description="versuck-ng's purpose is to calculate the default WEP key for Verizon issued Actiontec wireless routers.")
+	parser.add_argument("-m", "--mac", dest="mac",nargs=1, help="Mac Address")
+	parser.add_argument("-e", "--essid", dest="essid",nargs=1, help="essid")
 
 	if len(sys.argv) <= 1:
 		banner()
 		parser.print_help()
 		sys.exit(0)
-	(options, args) = parser.parse_args()
-	data = createKey(options.essid,options.mac)
+	args = parser.parse_args()
+	data = createKey(args.essid[0],args.mac[0])
 	print("Key is most likely")
 	print(data["best"])
 	print("Key may also be one of these")


### PR DESCRIPTION
Fixes #2108

Looking for scripts containing optparse:

```
┌───(gemesa♾fedora)-[~/git-repos/aircrack-ng-sync]
└─$ grep -rnw . -e 'optparse'
./scripts/airdrop-ng/airdrop-ng:11:import sys, optparse, re, time, random, os
./scripts/airdrop-ng/airdrop-ng:943:    parser = optparse.OptionParser("usage: %prog options [-i,-t,-r] -s -p -b -n")  #
./scripts/airgraph-ng/airodump-join:3:import sys,getopt, optparse, pdb, re
./scripts/airgraph-ng/airodump-join:75:	parser = optparse.OptionParser("usage: %prog [options] arg1 arg2 arg3 .....")
./scripts/versuck-ng/versuck-ng:12:import optparse, sys
./scripts/versuck-ng/versuck-ng:50:	parser = optparse.OptionParser("usage: %prog options -m -e")
```
Validating the old optparser and the new argparser code with PyCharm debugger:

```
$ python airdrop-ng -i mon0 -t airodump.csv -r rulefile.txt -s 100 -b -l logfile.txt -n 3
```
optparse
```
args = ['logfile.txt']
options = {'card': 'mon0', 'data': 'airodump.csv', 'rule': 'rulefile.txt', 'slept': 100, 'debug': True, 'log': True, 'nap': '3'}
```
argparse
```
args = Namespace(card=['mon0'], data=['airodump.csv'], rule=['rulefile.txt'], slept=[100], debug=True, log='logfile.txt', nap=['3'])
```
---
```
$ python airdrop-ng -i mon0 -t airodump.csv -r rulefile.txt -s 100 -b -l -n 3
```
optparse
```
args = []
options = {'card': 'mon0', 'data': 'airodump.csv', 'rule': 'rulefile.txt', 'slept': 100, 'debug': True, 'log': True, 'nap': '3'}
```
argparse
```
args = Namespace(card=['mon0'], data=['airodump.csv'], rule=['rulefile.txt'], slept=[100], debug=True, log=True, nap=['3'])
```
---
```
$ python airdrop-ng -i mon0 -t airodump.csv -r rulefile.txt -s 100 -b -n 3
```
optparse
```
args = []
options = {'card': 'mon0', 'data': 'airodump.csv', 'rule': 'rulefile.txt', 'slept': 100, 'debug': True, 'log': False, 'nap': '3'}
```
argparse
```
args = Namespace(card=['mon0'], data=['airodump.csv'], rule=['rulefile.txt'], slept=[100], debug=True, log=False, nap=['3'])
```
---
```
$ python airodump-join -o out -i in1 in2 in3
```
optparse
```
args = ['in3']
options = {'output': 'out', 'filename': ('in1', 'in2')}
```
argparse
```
args = Namespace(output=['out'], filename=['in1', 'in2', 'in3'])
```
---
```
$ python versuck-ng -m 123 -e 456
```
optparse
```
args = []
options = {'mac': '123', 'essid': '456'}
```
argparse
```
args = Namespace(mac=['123'], essid=['456'])
```

Switching to argparser means the --help output will also change, for example:

```
$ python airdrop-ng --help
#################################################
#             Welcome to AirDrop-ng             #
#################################################

Usage: airdrop-np-original options [-i,-t,-r] -s -p -b -n

Options:
  -h, --help            show this help message and exit
  -i CARD, --interface=CARD
                        Wireless card in monitor mode to inject from
  -t DATA, --dump=DATA  Airodump txt file in CSV format NOT the pcap
  -r RULE, --rule=RULE  Rule File for matched deauths
  -s SLEPT, --sleep=SLEPT
                        Time to sleep between sending each packet
  -b, --debug           Turn on Rule Debugging
  -l, --logging         Enable Logging to a file, if file path not provided
                        airdrop will log to default location
  -n NAP, --nap=NAP     Time to sleep between loops
```
will be instead:
```
$ python airdrop-ng --help
#################################################
#             Welcome to AirDrop-ng             #
#################################################

usage: airdrop-ng [-h] [-i CARD] [-t DATA] [-r RULE] [-s SLEPT] [-b]
                  [-l [LOG]] [-n NAP]

airdrop-ng is a program used for targeted, rule-based deauthentication of
users.

options:
  -h, --help            show this help message and exit
  -i CARD, --interface CARD
                        Wireless card in monitor mode to inject from
  -t DATA, --dump DATA  Airodump txt file in CSV format NOT the pcap
  -r RULE, --rule RULE  Rule File for matched deauths
  -s SLEPT, --sleep SLEPT
                        Time to sleep between sending each packet
  -b, --debug           Turn on Rule Debugging
  -l [LOG], --logging [LOG]
                        Enable Logging to a file, if file path not provided
                        airdrop will log to default location
  -n NAP, --nap NAP     Time to sleep between loops

```

Related wiki pages:
- https://www.aircrack-ng.org/doku.php?id=airdrop-ng
- https://www.aircrack-ng.org/doku.php?id=tools#versuck-ng
