### PR TITLE
airodump-ng: add multiple interface option to manpage

### DIFF
--- a/manpages/airodump-ng.8.in
+++ b/manpages/airodump-ng.8.in
@@ -4,7 +4,7 @@
 airodump-ng - a wireless packet capture tool for aircrack-ng
 .SH SYNOPSIS
 .B airodump-ng
-[options] <interface name>
+[options] <interface name>[,<interface name>,...]
 .SH DESCRIPTION
 .BI airodump-ng
 is used for packet capturing of raw 802.11 frames for the intent of using them with aircrack-ng. If you have a GPS receiver connected to the computer, airodump-ng is capable of logging the coordinates of the found access points. Additionally, airodump-ng writes out a text file containing the details of all access points and clients seen.


### PR DESCRIPTION
Fixes #2319 

Usage:
```
$ ./airodump-ng --help

  Airodump-ng 1.7 rev e99b9709 - (C) 2006-2022 Thomas d'Otreppe
  https://www.aircrack-ng.org

  usage: airodump-ng <options> <interface>[,<interface>,...]

  Options:
...
```

manpage before:
```
$ man ./airodump-ng.8.in
AIRODUMP-NG(8)                                System Manager's Manual                                AIRODUMP-NG(8)

NAME
       airodump-ng - a wireless packet capture tool for aircrack-ng

SYNOPSIS
       airodump-ng [options] <interface name>

DESCRIPTION
...
```
manpage after:
```
AIRODUMP-NG(8)                                System Manager's Manual                                AIRODUMP-NG(8)

NAME
       airodump-ng - a wireless packet capture tool for aircrack-ng

SYNOPSIS
       airodump-ng [options] <interface name>[,<interface name>,...]

DESCRIPTION
```