### PR TITLE
airdecloak-ng: add "--null-packets not yet implemented" info to manpage

### DIFF
--- a/manpages/airdecloak-ng.1.in
+++ b/manpages/airdecloak-ng.1.in
@@ -30,7 +30,7 @@ Essid of the network (not yet implemented) to filter.
 BSSID of the network to filter.
 .TP
 .I --null-packets
-Assume that null packets can be cloaked.
+Assume that null packets can be cloaked (not yet implemented).
 .TP
 .I --disable-base-filter
 Do not apply base filter.


### PR DESCRIPTION
This is a follow-up of #2378 where I forgot to update the manpage also. Now I fixed it.