### PR TITLE
switch from distutils to setuptools

### DIFF
--- a/scripts/airdrop-ng/setup.py
+++ b/scripts/airdrop-ng/setup.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 # This file is Copyright David Francos Cuartero, licensed under the GPL2 license.
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='airdrop-ng',
       version='1.1',
       description='Rule based Deauth Tool',
       author='TheX1le',
-      console = [{"script": "airdrop-ng" }],
       url='https://aircrack-ng.org',
       license='GPL2',
       classifiers=[ 'Development Status :: 4 - Beta', ],

--- a/scripts/airgraph-ng/setup.py
+++ b/scripts/airgraph-ng/setup.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 # This file is Copyright David Francos Cuartero, licensed under the GPL2 license.
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='airgraph-ng',
       version='1.1',
       description='Aircrack-ng network grapher',
       author='TheX1le',
-      console = [{"script": "airgraph-ng" }],
       url='https://aircrack-ng.org',
       license='GPL2',
       classifiers=[


### PR DESCRIPTION
Fixes #2352 

Looking for scripts with distutils:

```
┌───(gemesa♾fedora)-[~/git-repos/aircrack-ng-sync]
└─$ grep -rnw . -e 'distutils'
./scripts/airdrop-ng/setup.py:4:from distutils.core import setup
./scripts/airgraph-ng/setup.py:4:from distutils.core import setup
```

The unknown "console" option has been removed.

Compilation works as expected after adding setuptools:

```
$ make
make --no-print-directory all-recursive
Making all in manpages
make[2]: Nothing to be done for 'all'.
Making all in scripts
Making all in airdrop-ng
Making all in doc
make[4]: Nothing to be done for 'all'.
( cd . && python setup.py build \
        --build-base /home/gemesa/git-repos/aircrack-ng/scripts/airdrop-ng/build \
        --verbose )
running build
running build_py
creating /home/gemesa/git-repos/aircrack-ng/scripts/airdrop-ng/build
creating /home/gemesa/git-repos/aircrack-ng/scripts/airdrop-ng/build/lib
creating /home/gemesa/git-repos/aircrack-ng/scripts/airdrop-ng/build/lib/airdrop
copying airdrop/__init__.py -> /home/gemesa/git-repos/aircrack-ng/scripts/airdrop-ng/build/lib/airdrop
copying airdrop/libDumpParse.py -> /home/gemesa/git-repos/aircrack-ng/scripts/airdrop-ng/build/lib/airdrop
copying airdrop/libOuiParse.py -> /home/gemesa/git-repos/aircrack-ng/scripts/airdrop-ng/build/lib/airdrop
running build_scripts
creating /home/gemesa/git-repos/aircrack-ng/scripts/airdrop-ng/build/scripts-3.11
copying and adjusting airdrop-ng -> /home/gemesa/git-repos/aircrack-ng/scripts/airdrop-ng/build/scripts-3.11
changing mode of /home/gemesa/git-repos/aircrack-ng/scripts/airdrop-ng/build/scripts-3.11/airdrop-ng from 644 to 755
Making all in airgraph-ng
Making all in man
make[4]: Nothing to be done for 'all'.
( cd . && python setup.py build \
        --build-base /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build \
        --verbose )
running build
running build_py
creating /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build
creating /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build/lib
creating /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build/lib/airgraphviz
copying airgraphviz/__init__.py -> /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build/lib/airgraphviz
copying airgraphviz/libDumpParse.py -> /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build/lib/airgraphviz
copying airgraphviz/libOuiParse.py -> /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build/lib/airgraphviz
copying airgraphviz/lib_Airgraphviz.py -> /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build/lib/airgraphviz
running build_scripts
creating /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build/scripts-3.11
copying and adjusting airodump-join -> /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build/scripts-3.11
copying and adjusting airgraph-ng -> /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build/scripts-3.11
changing mode of /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build/scripts-3.11/airodump-join from 644 to 755
changing mode of /home/gemesa/git-repos/aircrack-ng/scripts/airgraph-ng/build/scripts-3.11/airgraph-ng from 644 to 755
Making all in versuck-ng
make[3]: Nothing to be done for 'all'.
make[3]: Nothing to be done for 'all-am'.

```