### PR TITLE
workflows: fix gcc and clang in macos.yml

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,10 +32,10 @@ jobs:
         compiler:
           - cc:  gcc-11
             cxx: g++-11
-          #- cc:  gcc-10
-          #  cxx: g++-10
-          #- cc:  gcc-9
-          #  cxx: g++-9
+          - cc:  gcc-10
+            cxx: g++-10
+          - cc:  gcc-9
+            cxx: g++-9
           #- cc:  clang-11     broken handling with version.h
           #  cxx: clang++-11
           - cc:  clang-12
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install autoconf automake ccache cmocka expect hwloc libpcap libtool openssl pcre2 pkg-config sqlite3 shtool md5sha1sum
+          brew install gcc@9 gcc@10 autoconf automake ccache cmocka expect hwloc libpcap libtool openssl pcre2 pkg-config sqlite3 shtool md5sha1sum
 
       - name: Ccache stats before builds
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,8 +36,8 @@ jobs:
             cxx: g++-10
           - cc:  gcc-9
             cxx: g++-9
-          #- cc:  clang-11     broken handling with version.h
-          #  cxx: clang++-11
+          - cc:  clang-11
+            cxx: clang++-11
           - cc:  clang-12
             cxx: clang++-12
         flags:

--- a/lib/ce-wpa/crypto_engine.c
+++ b/lib/ce-wpa/crypto_engine.c
@@ -71,7 +71,7 @@ EXPORT int ac_crypto_engine_supported_features(void)
 #endif
 }
 
-EXPORT int ac_crypto_engine_simd_width()
+EXPORT int ac_crypto_engine_simd_width(void)
 {
 #ifdef SIMD_COEF_32
 	return SIMD_COEF_32;

--- a/lib/ce-wpa/wpapsk.c
+++ b/lib/ce-wpa/wpapsk.c
@@ -325,7 +325,7 @@ static MAYBE_INLINE void wpapsk_sse(ac_crypto_engine_t * engine,
 }
 #endif
 
-void init_atoi()
+void init_atoi(void)
 {
 	memset(atoi64, 0x7F, sizeof(atoi64));
 	for (char const * pos = itoa64; pos != &itoa64[63]; pos++)

--- a/lib/libac/cpu/simd_cpuid.c
+++ b/lib/libac/cpu/simd_cpuid.c
@@ -679,7 +679,7 @@ static unsigned int cpuid_x86_physical_cores(void)
 }
 #endif
 
-int cpuid_getinfo()
+int cpuid_getinfo(void)
 {
 	int cpu_count = get_nb_cpus();
 	float cpu_temp;

--- a/lib/libac/tui/console.c
+++ b/lib/libac/tui/console.c
@@ -89,7 +89,7 @@ void textstyle(int attr)
 	fflush(channel);
 }
 
-void reset_term()
+void reset_term(void)
 {
 	struct termios oldt, newt;
 

--- a/src/aireplay-ng/aireplay-ng.c
+++ b/src/aireplay-ng/aireplay-ng.c
@@ -3323,7 +3323,7 @@ static int do_attack_chopchop(void)
 	unsigned char b2 = 0xAA;
 
 	FILE * f_cap_out;
-	long nb_pkt_read;
+	//long nb_pkt_read;
 	unsigned long crc_mask;
 	unsigned char * chopped;
 
@@ -3517,7 +3517,7 @@ static int do_attack_chopchop(void)
 
 	memset(ticks, 0, sizeof(ticks));
 
-	nb_pkt_read = 0;
+	//nb_pkt_read = 0;
 	nb_pkt_sent = 0;
 	nb_bad_pkt = 0;
 	guess = 256;
@@ -3765,7 +3765,7 @@ static int do_attack_chopchop(void)
 
 		if (n == 0) continue;
 
-		nb_pkt_read++;
+		//nb_pkt_read++;
 
 		/* check if it's a deauth packet */
 

--- a/src/tkiptun-ng/tkiptun-ng.c
+++ b/src/tkiptun-ng/tkiptun-ng.c
@@ -1310,7 +1310,7 @@ static int do_attack_tkipchop(unsigned char * src_packet, int src_packet_len)
 	unsigned char rc4key[16], keystream[4096];
 
 	FILE * f_cap_out;
-	long nb_pkt_read;
+	//long nb_pkt_read;
 	unsigned long crc_mask;
 	unsigned char * chopped;
 
@@ -1515,7 +1515,7 @@ static int do_attack_tkipchop(unsigned char * src_packet, int src_packet_len)
 
 	memset(ticks, 0, sizeof(ticks));
 
-	nb_pkt_read = 0;
+	//nb_pkt_read = 0;
 	nb_pkt_sent = 0;
 	nb_bad_pkt = 0;
 	guess = 256;
@@ -1790,7 +1790,7 @@ static int do_attack_tkipchop(unsigned char * src_packet, int src_packet_len)
 		}
 		if (n == 0) continue;
 
-		nb_pkt_read++;
+		//nb_pkt_read++;
 
 		/* check if it's a deauth packet */
 


### PR DESCRIPTION
Fixes #2376 

Added `gcc-9` (`gcc@9`) and `gcc-10` (`gcc@10`) to the install dependencies to fix `gcc-9` and `gcc-10`.

After enabling `clang-11`, it was necessary to add missing void keywords to some function definitions and to comment out some unused but set variables to fix `clang-11`. These were necessary because `clang-11` on MacOs is very strict for some reason and raises -Wunused-but-set-variable and can not match the function declaration and the function definition if the void keyword is missing from the argument, for example:

```
void init_atoi(void);
void init_atoi()
{
 ...
}
```

Since I have no Apple HW so I can not test building myself, I have been using the MacOs runner to do that for me. This generated a lot of junk action which can be removed. Sorry about that.