### PR TITLE
fix PPC64LE build issue

### DIFF
--- a/include/aircrack-ng/ce-wpa/pseudo_intrinsics.h
+++ b/include/aircrack-ng/ce-wpa/pseudo_intrinsics.h
@@ -144,6 +144,12 @@ static inline int vanyeq_epi32(vtype x, vtype y)
 #elif __ALTIVEC__
 #include <altivec.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 typedef vector unsigned int vtype32;
 typedef vector unsigned long vtype64;
 typedef union {

--- a/lib/ce-wpa/simd-intrinsics.c
+++ b/lib/ce-wpa/simd-intrinsics.c
@@ -1392,12 +1392,21 @@ void SIMDSHA1body(vtype * _data,
 				  ARCH_WORD_32 * reload_state,
 				  unsigned SSEi_flags)
 {
+#if __ALTIVEC__
+	vtype w[16 * SIMD_PARA_SHA1] = {{{0}}};
+	vtype a[SIMD_PARA_SHA1] = {{{0}}};
+	vtype b[SIMD_PARA_SHA1] = {{{0}}};
+	vtype c[SIMD_PARA_SHA1] = {{{0}}};
+	vtype d[SIMD_PARA_SHA1] = {{{0}}};
+	vtype e[SIMD_PARA_SHA1] = {{{0}}};
+#else
 	vtype w[16 * SIMD_PARA_SHA1] = {(vtype){0}};
 	vtype a[SIMD_PARA_SHA1] = {(vtype){0}};
 	vtype b[SIMD_PARA_SHA1] = {(vtype){0}};
 	vtype c[SIMD_PARA_SHA1] = {(vtype){0}};
 	vtype d[SIMD_PARA_SHA1] = {(vtype){0}};
 	vtype e[SIMD_PARA_SHA1] = {(vtype){0}};
+#endif
 	vtype tmp[SIMD_PARA_SHA1];
 	vtype cst;
 	unsigned int i;


### PR DESCRIPTION
Fixes #2392 

There are 2 issues in the CI log mentioned in #2392 to be solved:
```
#10 414.2 /aircrack-ng/include/aircrack-ng/ce-wpa/pseudo_intrinsics.h:161:18: error: ISO C forbids casts to union type [-Werror=pedantic]
#10 414.2   161 | #define vload(m) (vtype)(vtype32) vec_ld(0, (uint32_t *) (m))
```
```
#10 412.8 lib/ce-wpa/simd-intrinsics.c:1395:40: error: missing braces around initializer [-Werror=missing-braces]
#10 412.8  1395 |         vtype w[16 * SIMD_PARA_SHA1] = {(vtype){0}};
```

## Initialization issue
On some archs this initialization is working:
```
void SIMDSHA1body(vtype * _data,
				  ARCH_WORD_32 * out,
				  ARCH_WORD_32 * reload_state,
				  unsigned SSEi_flags)
{
	vtype w[16 * SIMD_PARA_SHA1] = {(vtype){0}};
	vtype a[SIMD_PARA_SHA1] = {(vtype){0}};
	vtype b[SIMD_PARA_SHA1] = {(vtype){0}};
	vtype c[SIMD_PARA_SHA1] = {(vtype){0}};
	vtype d[SIMD_PARA_SHA1] = {(vtype){0}};
	vtype e[SIMD_PARA_SHA1] = {(vtype){0}};
...
```
but on some other ones (like ppc64le) it is not, meaning the compiler raises `-Wmissing-braces` warnings. On ppc64le this is working for example:
```
void SIMDSHA1body(vtype * _data,
				  ARCH_WORD_32 * out,
				  ARCH_WORD_32 * reload_state,
				  unsigned SSEi_flags)
{
	vtype w[16 * SIMD_PARA_SHA1] = {{{0}}};
	vtype a[SIMD_PARA_SHA1] = {{{0}}};
	vtype b[SIMD_PARA_SHA1] = {{{0}}};
	vtype c[SIMD_PARA_SHA1] = {{{0}}};
	vtype d[SIMD_PARA_SHA1] = {{{0}}};
	vtype e[SIMD_PARA_SHA1] = {{{0}}};
...
```
but then this causes [problems on other archs](https://github.com/gemesa/aircrack-ng/actions/runs/4008734218/jobs/6883263554). So a generic initialization mechanism (like `memset`) is necessary:
```
void SIMDSHA1body(vtype * _data,
				  ARCH_WORD_32 * out,
				  ARCH_WORD_32 * reload_state,
				  unsigned SSEi_flags)
{
	vtype w[16 * SIMD_PARA_SHA1];
	memset(w, 0, sizeof(w));
	vtype a[SIMD_PARA_SHA1];
	memset(a, 0, sizeof(a));
	vtype b[SIMD_PARA_SHA1];
	memset(b, 0, sizeof(b));
	vtype c[SIMD_PARA_SHA1];
	memset(c, 0, sizeof(c));
	vtype d[SIMD_PARA_SHA1];
	memset(d, 0, sizeof(d));
	vtype e[SIMD_PARA_SHA1];
	memset(e, 0, sizeof(e));
...
```
I do not understand though why we need to initialize to 0 because in the [original code](https://github.com/openwall/john/blob/bleeding-jumbo/src/simd-intrinsics.c) of john the ripper they do not initialize but [we do it on purpose](https://github.com/aircrack-ng/aircrack-ng/commit/c5e877e346a0ae5001163ea9915ce0f2cd791b28). I do not know anything about SIMD and vectors though so I am missing something probably.

## Casting to union issue
Disabling `-Wpedantic` is necessary because `vtype` is a `union` when building for ppc64le and casting to `union` type is not allowed when `-Wpedantic` is supplied. The code is relying heavily on this `union` type and it would be very difficult to remove. The [original code](https://github.com/openwall/john/blob/bleeding-jumbo/src/pseudo_intrinsics.h) of john is using the same `union` based approach also. I know suppressing `-Wpedantic` is hacky but `pseudo_intrinsics.h` is only included in `simd-intrinsics.c` (so would not affect other modules) and we would do it only when we build with `__ALTIVEC__` defined.

The proposed patches [fix](https://github.com/gemesa/aircrack-ng/actions/runs/4008935809/jobs/6883699259) the ppc62le build issues.

[This](https://github.com/gemesa/aircrack-ng/commits/docker-pseudo) is the branch I used for testing (might be deleted later).
[These](https://github.com/gemesa/aircrack-ng/actions/workflows/docker.yml) are the docker builds I triggered manually while pushing commits to my test branch (might be deleted later).