### PR TITLE
workflows: fix clang CC, CXX and CFLAGS in linux-pcre.yml

### DIFF
--- a/.github/workflows/linux-pcre.yml
+++ b/.github/workflows/linux-pcre.yml
@@ -128,15 +128,9 @@ jobs:
         run: |
           CPUS=$(nproc)
           case "${{ matrix.compiler.cc }}" in
-            clang-12)
-              CC=clang-11
-              CXX=clang++-11
-              export CFLAGS="-Werror -Wno-zero-length-array -Wno-deprecated-declarations"
-              export CXXFLAGS="-Werror -Wno-zero-length-array -Wno-deprecated-declarations"
-              ;;
-            clang-11)
-              CC=clang-11
-              CXX=clang++-11
+            clang)
+              CC=clang
+              CXX=clang++
               export CFLAGS="-Werror -Wno-zero-length-array -Wno-deprecated-declarations"
               export CXXFLAGS="-Werror -Wno-zero-length-array -Wno-deprecated-declarations"
               ;;


### PR DESCRIPTION
I forgot to update that part in #2402 when I changed the compilers to default `gcc` and `clang`.