### PR TITLE
workflows: upgrade to actions/checkout@v3

### DIFF
--- a/.github/workflows/linux-pcre.yml
+++ b/.github/workflows/linux-pcre.yml
@@ -100,7 +100,7 @@ jobs:
     name: Ubuntu 22.04 ${{ matrix.compiler.cc }} using ${{ matrix.flags.name }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 750
           submodules: 'recursive'
@@ -185,7 +185,7 @@ jobs:
     name: Ubuntu 20.04 ${{ matrix.compiler.cc }} using ${{ matrix.flags.name }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 750
           submodules: 'recursive'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -102,7 +102,7 @@ jobs:
     name: Ubuntu 22.04 ${{ matrix.compiler.cc }} using ${{ matrix.flags.name }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 750
           submodules: 'recursive'
@@ -221,7 +221,7 @@ jobs:
     name: Ubuntu 20.04 ${{ matrix.compiler.cc }} using ${{ matrix.flags.name }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 750
           submodules: 'recursive'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -100,7 +100,7 @@ jobs:
     name: macOS ${{ matrix.compiler.cc }} using ${{ matrix.flags.name }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 750
           submodules: 'recursive'

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         env:
           PVS_STUDIO_NAME: ${{ secrets.PvsStudioName }}
           PVS_STUDIO_KEY: ${{ secrets.PvsStudioKey }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -84,7 +84,7 @@ jobs:
     name: Clang-Format
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - run: git config --global core.autocrlf input
       - run: git config --global core.eol lf
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Caching Cygwin fails due to /dev files and symlinks, sad :(
       - uses: actions/cache@v2
@@ -258,7 +258,7 @@ jobs:
       - run: git config --global core.autocrlf input
       - run: git config --global core.eol lf
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Checkout GUI source code
         shell: pwsh
@@ -295,7 +295,7 @@ jobs:
       - run: git config --global core.autocrlf input
       - run: git config --global core.eol lf
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Cygwin
         uses: cygwin/cygwin-install-action@v3


### PR DESCRIPTION
This fixes the following warnings from GitHub Actions:

```
Node.js 12 actions are deprecated. Please update the following
actions to use Node.js 16: actions/checkout@v2.
```