### PR TITLE
airbase-ng: remove --netmask related dead code

### DIFF
--- a/src/airbase-ng/airbase-ng.c
+++ b/src/airbase-ng/airbase-ng.c
@@ -3819,14 +3819,6 @@ int main(int argc, char * argv[])
 		return (EXIT_FAILURE);
 	}
 
-	if ((memcmp(opt.f_netmask, NULL_MAC, 6) != 0)
-		&& (memcmp(opt.f_bssid, NULL_MAC, 6) == 0))
-	{
-		printf("Notice: specify bssid \"--bssid\" with \"--netmask\"\n");
-		printf("\"%s --help\" for help.\n", argv[0]);
-		return (EXIT_FAILURE);
-	}
-
 	if (lopt.mitm && (getMACcount(rBSSID) != 1 || getMACcount(rClient) < 1))
 	{
 		printf("Notice: You need to specify exactly one BSSID (-b)"


### PR DESCRIPTION
Removed `--netmask` related dead code from `airbase-ng` as `airbase-ng` has no such option, probably a copy-paste error. Noticed while working on #1940 and #2432.