### PR TITLE
src: fix missing include build errors on alpine

### DIFF
--- a/src/airbase-ng/airbase-ng.c
+++ b/src/airbase-ng/airbase-ng.c
@@ -38,7 +38,12 @@
 #include "config.h"
 #endif
 
+#ifdef linux
+#include <linux/rtc.h>
+#endif
+
 #include <sys/types.h>
+#include <sys/ioctl.h>
 #include <sys/time.h>
 
 #include <pthread.h>

--- a/src/aireplay-ng/aireplay-ng.c
+++ b/src/aireplay-ng/aireplay-ng.c
@@ -39,8 +39,13 @@
 #include "config.h"
 #endif
 
+#if defined(linux)
+#include <linux/rtc.h>
+#endif
+
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <sys/time.h>
 
 #include <netinet/in.h>

--- a/src/airtun-ng/airtun-ng.c
+++ b/src/airtun-ng/airtun-ng.c
@@ -38,6 +38,11 @@
 #include "config.h"
 #endif
 
+#ifdef linux
+#include <linux/rtc.h>
+#endif
+
+#include <sys/ioctl.h>
 #include <sys/time.h>
 
 #include <unistd.h>
@@ -46,6 +51,8 @@
 #include <stdio.h>
 #include <errno.h>
 #include <getopt.h>
+
+#include <fcntl.h>
 
 #include "aircrack-ng/defs.h"
 #include "aircrack-ng/version.h"

--- a/src/easside-ng/easside-ng.c
+++ b/src/easside-ng/easside-ng.c
@@ -29,6 +29,7 @@
 #include <err.h>
 #include <fcntl.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <sys/stat.h>
 #include <signal.h>
 #include <sys/time.h>

--- a/src/packetforge-ng/packetforge-ng.c
+++ b/src/packetforge-ng/packetforge-ng.c
@@ -43,6 +43,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <sys/types.h>
 #include <getopt.h>
 
 #include "aircrack-ng/defs.h"

--- a/src/tkiptun-ng/tkiptun-ng.c
+++ b/src/tkiptun-ng/tkiptun-ng.c
@@ -38,9 +38,21 @@
 #include "config.h"
 #endif
 
+#if defined(linux)
+#include <linux/rtc.h>
+#endif
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
 #include <sys/time.h>
 
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <unistd.h>
+#include <dirent.h>
+#include <signal.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -49,8 +61,15 @@
 #include <getopt.h>
 
 #include <fcntl.h>
+#include <ctype.h>
 
 #include <limits.h>
+
+#if defined(linux)
+#include <netinet/in_systm.h>
+#include <netinet/ip.h>
+#include <netinet/tcp.h>
+#endif
 
 #include "aircrack-ng/defs.h"
 #include "aircrack-ng/version.h"


### PR DESCRIPTION
Fixes #2429 

You are right, I introduced these errors in #2418, thats my bad.

Note: I needed to put the following includes under `#if defined(linux)` otherwise they break the BSD builds:
```
#if defined(linux)
#include <netinet/in_systm.h>
#include <netinet/ip.h>
#include <netinet/tcp.h>
#endif
```