### PR TITLE
airodump-ng: add support for multiple --bssid

### DIFF
--- a/include/aircrack-ng/support/common.h
+++ b/include/aircrack-ng/support/common.h
@@ -96,6 +96,13 @@ int64_t ftello64(FILE * fp);
 extern "C" {
 #endif
 
+typedef struct MAC_list * pMAC_t;
+struct MAC_list
+{
+	unsigned char mac[6];
+	pMAC_t next;
+};
+
 static const unsigned char ZERO[33] = "\x00\x00\x00\x00\x00\x00\x00\x00"
 									  "\x00\x00\x00\x00\x00\x00\x00\x00"
 									  "\x00\x00\x00\x00\x00\x00\x00\x00"
@@ -186,6 +193,12 @@ int hexStringToArray(char * in,
 
 /// Return the mac address bytes (or null if it's not a mac address)
 int getmac(const char * macAddress, const int strict, unsigned char * mac);
+
+int addMAC(pMAC_t pMAC, unsigned char * mac);
+
+int getMACcount(pMAC_t pMAC);
+
+int flushMACs(pMAC_t pMAC);
 
 /// Read a line of characters inputted by the user
 int readLine(char line[], int maxlength);

--- a/lib/libac/support/common.c
+++ b/lib/libac/support/common.c
@@ -579,6 +579,66 @@ int getmac(const char * macAddress, const int strict, unsigned char * mac)
 	return 0;
 }
 
+int addMAC(pMAC_t pMAC, unsigned char * mac)
+{
+	pMAC_t cur = pMAC;
+
+	if (mac == NULL) return -1;
+
+	if (pMAC == NULL) return -1;
+
+	while (cur->next != NULL) cur = cur->next;
+
+	// alloc mem
+	cur->next = (pMAC_t) malloc(sizeof(struct MAC_list));
+	ALLEGE(cur->next != NULL);
+	cur = cur->next;
+
+	// set mac
+	memcpy(cur->mac, mac, 6);
+
+	cur->next = NULL;
+
+	return 0;
+}
+
+int getMACcount(pMAC_t pMAC)
+{
+	pMAC_t cur = pMAC;
+	int count = 0;
+
+	if (pMAC == NULL) return (-1);
+
+	while (cur->next != NULL)
+	{
+		cur = cur->next;
+		count++;
+	}
+
+	return (count);
+}
+
+int flushMACs(pMAC_t pMAC)
+{
+	pMAC_t old;
+	pMAC_t cur;
+	cur = pMAC;
+
+	if (pMAC == NULL) return -1;
+
+	while (cur->next != NULL)
+	{
+		old = cur->next;
+		cur->next = old->next;
+
+		memset(old->mac, 0, sizeof(old->mac));
+		old->next = NULL;
+		free(old);
+	}
+
+	return (0);
+}
+
 // Read a line of characters inputted by the user
 int readLine(char line[], int maxlength)
 {

--- a/manpages/airodump-ng.8.in
+++ b/manpages/airodump-ng.8.in
@@ -98,7 +98,7 @@ Removes the message that says \(aqfixed channel <interface>: -1\(aq.
 It will only show networks matching the given encryption. Note that WPA is a shortcut for WPA1, WPA2 and WPA3. May be specified more than once: \(aq\-t OPN \-t WPA2\(aq
 .TP
 .I -d <bssid>, --bssid <bssid>
-It will only show networks, matching the given bssid.
+It will only show networks, matching the given bssid. You can pass multiple --bssid options.
 .TP
 .I -m <mask>, --netmask <mask>
 It will only show networks, matching the given bssid ^ netmask combination. Need \-\-bssid (or \-d) to be specified.

--- a/src/airbase-ng/airbase-ng.c
+++ b/src/airbase-ng/airbase-ng.c
@@ -266,13 +266,6 @@ struct ESSID_list
 	time_t expire;
 };
 
-typedef struct MAC_list * pMAC_t;
-struct MAC_list
-{
-	unsigned char mac[6];
-	pMAC_t next;
-};
-
 #include "aircrack-ng/support/station.h"
 
 typedef struct CF_packet * pCF_t;
@@ -446,29 +439,6 @@ static int capture_packet(unsigned char * packet, int length)
 		flock(fileno(opt.f_cap), LOCK_UN);
 #endif
 	}
-	return 0;
-}
-
-static int addMAC(pMAC_t pMAC, unsigned char * mac)
-{
-	pMAC_t cur = pMAC;
-
-	if (mac == NULL) return -1;
-
-	if (pMAC == NULL) return -1;
-
-	while (cur->next != NULL) cur = cur->next;
-
-	// alloc mem
-	cur->next = (pMAC_t) malloc(sizeof(struct MAC_list));
-	ALLEGE(cur->next != NULL);
-	cur = cur->next;
-
-	// set mac
-	memcpy(cur->mac, mac, 6);
-
-	cur->next = NULL;
-
 	return 0;
 }
 
@@ -653,22 +623,6 @@ static int getESSIDcount(void)
 	}
 
 	ALLEGE(pthread_mutex_unlock(&rESSIDmutex) == 0);
-	return (count);
-}
-
-static int getMACcount(pMAC_t pMAC)
-{
-	pMAC_t cur = pMAC;
-	int count = 0;
-
-	if (pMAC == NULL) return (-1);
-
-	while (cur->next != NULL)
-	{
-		cur = cur->next;
-		count++;
-	}
-
 	return (count);
 }
 

--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -125,6 +125,8 @@ static int * frequencies;
 static volatile int quitting = 0;
 static volatile time_t quitting_event_ts = 0;
 
+static pMAC_t rBSSID;
+
 static void dump_sort(void);
 static void dump_print(int ws_row, int ws_col, int if_num);
 static char *
@@ -778,7 +780,8 @@ static const char usage[] =
 	"  Filter options:\n"
 	"      --encrypt   <suite>   : Filter APs by cipher suite\n"
 	"      --netmask <netmask>   : Filter APs by mask\n"
-	"      --bssid     <bssid>   : Filter APs by BSSID\n"
+	"      --bssid     <bssid>   : Filter APs by BSSID,\n"
+	"                              you can pass multiple --bssid options\n"
 	"      --essid     <essid>   : Filter APs by ESSID\n"
 #if defined HAVE_PCRE2 || defined HAVE_PCRE
 	"      --essid-regex <regex> : Filter APs by ESSID using a regular\n"
@@ -818,17 +821,25 @@ static int is_filtered_netmask(const uint8_t * bssid)
 	unsigned char mac1[6];
 	unsigned char mac2[6];
 	int i;
+	pMAC_t cur = rBSSID;
+	unsigned char match = 0;
 
-	for (i = 0; i < 6; i++)
+	while (cur->next != NULL)
 	{
-		mac1[i] = bssid[i] & opt.f_netmask[i];
-		mac2[i] = opt.f_bssid[i] & opt.f_netmask[i];
-	}
+		cur = cur->next;
+		for (i = 0; i < 6; i++)
+		{
+			mac1[i] = bssid[i] & opt.f_netmask[i];
+			mac2[i] = cur->mac[i] & opt.f_netmask[i];
+		}
 
-	if (memcmp(mac1, mac2, 6) != 0)
-	{
-		return (1);
+		if (memcmp(mac1, mac2, 6) == 0)
+		{
+			match = 1;
+			break;
+		}
 	}
+	if (match != 1) return (1);
 
 	return (0);
 }
@@ -1228,6 +1239,8 @@ static int dump_add_packet(unsigned char * h80211,
 	unsigned char clear[2048];
 	int weight[16];
 	int num_xor = 0;
+	pMAC_t cur = rBSSID;
+	unsigned char match = 0;
 
 	struct AP_info * ap_cur = NULL;
 	struct ST_info * st_cur = NULL;
@@ -1275,7 +1288,7 @@ static int dump_add_packet(unsigned char * h80211,
 			abort();
 	}
 
-	if (memcmp(opt.f_bssid, NULL_MAC, 6) != 0)
+	if (getMACcount(rBSSID) > 0)
 	{
 		if (memcmp(opt.f_netmask, NULL_MAC, 6) != 0)
 		{
@@ -1283,7 +1296,16 @@ static int dump_add_packet(unsigned char * h80211,
 		}
 		else
 		{
-			if (memcmp(opt.f_bssid, bssid, 6) != 0) return (1);
+			while (cur->next != NULL)
+			{
+				cur = cur->next;
+				if (memcmp(cur->mac, bssid, 6) == 0)
+				{
+					match = 1;
+					break;
+				}
+			}
+			if (match != 1) return (1);
 		}
 	}
 
@@ -5824,6 +5846,7 @@ int main(int argc, char * argv[])
 	int wi_read_failed = 0;
 	int n = 0;
 	int output_format_first_time = 1;
+	unsigned char mac[6];
 #ifdef HAVE_PCRE2
 	int pcreerror;
 	PCRE2_UCHAR pcreerrorbuf[256];
@@ -5903,6 +5926,10 @@ int main(int argc, char * argv[])
 
 	ALLEGE(pthread_mutex_init(&(lopt.mx_print), NULL) == 0);
 	ALLEGE(pthread_mutex_init(&(lopt.mx_sort), NULL) == 0);
+
+	rBSSID = (pMAC_t) malloc(sizeof(struct MAC_list));
+	ALLEGE(rBSSID != NULL);
+	memset(rBSSID, 0, sizeof(struct MAC_list));
 
 	textstyle(TEXT_RESET); //(TEXT_RESET, TEXT_BLACK, TEXT_WHITE);
 
@@ -6017,7 +6044,6 @@ int main(int argc, char * argv[])
 		lopt.channel[i] = 0;
 	}
 
-	memset(opt.f_bssid, '\x00', 6);
 	memset(opt.f_netmask, '\x00', 6);
 	memset(lopt.wpa_bssid, '\x00', 6);
 
@@ -6379,12 +6405,11 @@ int main(int argc, char * argv[])
 
 			case 'd':
 
-				if (memcmp(opt.f_bssid, NULL_MAC, 6) != 0)
+				if (getmac(optarg, 1, mac) == 0)
 				{
-					printf("Notice: bssid already given\n");
-					break;
+					addMAC(rBSSID, mac);
 				}
-				if (getmac(optarg, 1, opt.f_bssid) != 0)
+				else
 				{
 					printf("Notice: invalid bssid\n");
 					printf("\"%s --help\" for help.\n", argv[0]);
@@ -6631,8 +6656,7 @@ int main(int argc, char * argv[])
 
 	if (argc - optind == 1) lopt.s_iface = argv[argc - 1];
 
-	if ((memcmp(opt.f_netmask, NULL_MAC, 6) != 0)
-		&& (memcmp(opt.f_bssid, NULL_MAC, 6) == 0))
+	if ((memcmp(opt.f_netmask, NULL_MAC, 6) != 0) && (getMACcount(rBSSID) == 0))
 	{
 		printf("Notice: specify bssid \"--bssid\" with \"--netmask\"\n");
 		printf("\"%s --help\" for help.\n", argv[0]);
@@ -7457,6 +7481,9 @@ int main(int argc, char * argv[])
 			oui_cur = oui_next;
 		}
 	}
+
+	flushMACs(rBSSID);
+	free(rBSSID);
 
 	reset_term();
 	show_cursor();


### PR DESCRIPTION
Fixes #1940 

Added support for passing multiple `--bssid` options to `airodump-ng`. I used the implementation in `airbase-ng` as an example.

Since the following functions and types were already available in `airbase-ng` I reused them and moved them to `common.c` to avoid code duplication:
- `MAC_list`
- `pMAC_t`
- `addMAC()`
- `getMACcount()`

There was no function for freeing the MACs in the linked list so I created one:
- `flushMACs()`

I updated the info of `man airodump-ng` and `airodump-ng --help` also.

I tested `airodump-ng` with the following options:

Everything is displayed:
```
$ sudo ./airodump-ng wlan0mon
```

AP with address AA:AA:AA:AA:AA:AA is displayed:
```
$ sudo ./airodump-ng wlan0mon --bssid AA:AA:AA:AA:AA:AA
```

APs with address AA:AA:AA:AA:AA:AA or BB:BB:BB:BB:BB:BB are displayed:
```
$ sudo ./airodump-ng wlan0mon --bssid AA:AA:AA:AA:AA:AA --bssid BB:BB:BB:BB:BB:BB
```

APs starting with address AA:AA:AA or BB:BB:BB are displayed:
```
$ sudo ./airodump-ng wlan0mon --bssid AA:AA:AA:AA:AA:AA --bssid BB:BB:BB:BB:BB:BB --netmask FF:FF:FF:00:00:00
```

APs starting with AA:AA:AA or BB:BB:BB and containing \<ESSID\> in their ESSID are displayed:
```
$ sudo ./airodump-ng wlan0mon --bssid AA:AA:AA:AA:AA:AA --bssid BB:BB:BB:BB:BB:BB --netmask FF:FF:FF:00:00:00 --essid-regex "<ESSID>"
```

And it is working properly in all cases, at least fulfills my expectations. Can you test it also please and verify it is working as you would expect?