### PR TITLE
airodump-ng: color newly added clients also

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -124,6 +124,7 @@ static int * frequencies;
 
 static volatile int quitting = 0;
 static volatile time_t quitting_event_ts = 0;
+static unsigned char color_enabled = 0;
 
 static void dump_sort(void);
 static void dump_print(int ws_row, int ws_col, int if_num);
@@ -396,16 +397,23 @@ static THREAD_ENTRY(input_thread)
 					"][ Are you sure you want to quit? Press Q again to quit.");
 		}
 
-		if (keycode == KEY_o)
+		if ((keycode == KEY_o) || (color_enabled == 1))
 		{
 			color_on();
-			snprintf(lopt.message, sizeof(lopt.message), "][ color on");
+
+			if (keycode == KEY_o)
+			{
+				// display message only once (when key 'o' is pressed)
+				snprintf(lopt.message, sizeof(lopt.message), "][ color on");
+				color_enabled = 1;
+			}
 		}
 
 		if (keycode == KEY_p)
 		{
 			color_off();
 			snprintf(lopt.message, sizeof(lopt.message), "][ color off");
+			color_enabled = 0;
 		}
 
 		if (keycode == KEY_s)


### PR DESCRIPTION
Fixes #2109 

With this fix in `airodump-ng` newly added clients are auto-colored after pressing key 'o'. Key 'p' disables color as before.