### PR TITLE
airodump-ng: reword --bssid info in manpage

### DIFF
--- a/manpages/airodump-ng.8.in
+++ b/manpages/airodump-ng.8.in
@@ -98,7 +98,7 @@ Removes the message that says \(aqfixed channel <interface>: -1\(aq.
 It will only show networks matching the given encryption. Note that WPA is a shortcut for WPA1, WPA2 and WPA3. May be specified more than once: \(aq\-t OPN \-t WPA2\(aq
 .TP
 .I -d <bssid>, --bssid <bssid>
-It will only show networks, matching the given bssid. You can pass multiple --bssid options.
+It will only show networks, matching the given bssid. May be specified more than once: \(aq\-d 0D:F7:E2:61:C6:6D \-d 5B:62:A1:83:00:A8\(aq
 .TP
 .I -m <mask>, --netmask <mask>
 It will only show networks, matching the given bssid ^ netmask combination. Need \-\-bssid (or \-d) to be specified.


### PR DESCRIPTION
This is a follow-up of #2432 

I unified the manpage info (should have done it in the previous PR):

Before:
```
$ man ./airodump-ng.8.in
...
       -t <OPN|WEP|WPA|WPA1|WPA2|WPA3|OWE>, --encrypt <OPN|WEP|WPA|WPA1|WPA2|WPA3|OWE>
              It will only show networks matching the given encryption. Note that WPA is a shortcut for WPA1,  WPA2
              and WPA3. May be specified more than once: '-t OPN -t WPA2'

       -d <bssid>, --bssid <bssid>
              It will only show networks, matching the given bssid. You can pass multiple --bssid options.
...
```
After:
```
$ man ./airodump-ng.8.in
...
       -t <OPN|WEP|WPA|WPA1|WPA2|WPA3|OWE>, --encrypt <OPN|WEP|WPA|WPA1|WPA2|WPA3|OWE>
              It will only show networks matching the given encryption. Note that WPA is a shortcut for WPA1,  WPA2
              and WPA3. May be specified more than once: '-t OPN -t WPA2'

       -d <bssid>, --bssid <bssid>
              It  will  only  show  networks,  matching  the  given  bssid.  May  be  specified more than once: '-d
              0D:F7:E2:61:C6:6D -d 5B:62:A1:83:00:A8'
...
```