### PR TITLE
airbase-ng: fix -X (hidden SSID)

### DIFF
--- a/src/airbase-ng/airbase-ng.c
+++ b/src/airbase-ng/airbase-ng.c
@@ -2250,7 +2250,12 @@ packet_recv(uint8_t * packet, size_t length, struct AP_conf * apc, int external)
 
 					// insert essid
 					len = (size_t) getESSID(fessid);
-					if (!len)
+					if (lopt.hidden == 1)
+					{
+						memset(fessid, 0, sizeof(fessid));
+						len = 1;
+					}
+					else if (!len)
 					{
 						strncpy(fessid, "default", sizeof(fessid) - 1);
 						len = strlen(fessid);
@@ -2785,7 +2790,12 @@ static THREAD_ENTRY(beacon_thread)
 			/* flush expired ESSID entries */
 			flushESSID();
 			essid_len = (size_t) getNextESSID((char *) essid);
-			if (!essid_len)
+			if (lopt.hidden == 1)
+			{
+				memset(essid, 0, sizeof(essid));
+				essid_len = 1;
+			}
+			else if (!essid_len)
 			{
 				strncpy((char *) essid, "default", sizeof(essid) - 1);
 				essid_len = strlen("default"); //-V814


### PR DESCRIPTION
Fixes #1139
Fixes #1695 

With this change when `-X` option is supplied the ESSID of the `airbase-ng` AP is hidden (`<length: 1>`). I am no 802.11 expert, is this how it should work (see below)?

Before:
```
$ sudo ./airbase-ng -X -y -W 1 -e "AP" wlp0s20f0u1u2 -a 12:34:56:78:90:AB
20:44:56  Created tap interface at0
20:44:56  Trying to set MTU on at0 to 1500
20:44:56  Access Point with BSSID 12:34:56:78:90:AB started.
```

```
$ sudo ./airodump-ng wlan0mon --encrypt WEP
 CH  1 ][ Elapsed: 6 s ][ 2023-02-13 20:44 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH ESSID
                   
 12:34:56:78:90:AB    0       12        0    0   1   54   WEP  WEP         AP
```

After:
```
$ sudo ./airbase-ng -X -y -W 1 -e "AP" wlp0s20f0u1u2 -a 12:34:56:78:90:AB
20:34:29  Created tap interface at0
20:34:29  Trying to set MTU on at0 to 1500
20:34:29  Access Point with BSSID 12:34:56:78:90:AB started.
```
```
$ sudo ./airodump-ng wlan0mon --encrypt WEP
 CH  8 ][ Elapsed: 12 s ][ 2023-02-13 20:34 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH ESSID
                           
 12:34:56:78:90:AB   -1       46        0    0   1   54   WEP  WEP         <length:  1> 
```
---
```
$ sudo ./airbase-ng -X -W 1 -e "AP" wlp0s20f0u1u2 -a 12:34:56:78:90:AB 
20:34:10  Created tap interface at0
20:34:10  Trying to set MTU on at0 to 1500
20:34:10  Access Point with BSSID 12:34:56:78:90:AB started.
```

```
$ sudo ./airodump-ng wlan0mon --encrypt WEP
 CH  6 ][ Elapsed: 6 s ][ 2023-02-13 20:34 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH ESSID
                        
 12:34:56:78:90:AB  -28       40        0    0   1   54   WEP  WEP         <length:  1>
```
---
```
$ sudo ./airbase-ng -W 1 -e "AP" wlp0s20f0u2 -a 12:34:56:78:90:AB   
21:05:26  Created tap interface at0
21:05:26  Trying to set MTU on at0 to 1500
21:05:26  Access Point with BSSID 12:34:56:78:90:AB started.
```

```
$ sudo ./airodump-ng wlan0mon --encrypt WEP
 CH 10 ][ Elapsed: 0 s ][ 2023-02-13 21:05 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH ESSID

 12:34:56:78:90:AB  -60       13        0    0   1   54   WEP  WEP         AP 
```