### PR TITLE
airodump-ng: update multiple --essid related documentation

### DIFF
--- a/manpages/airodump-ng.8.in
+++ b/manpages/airodump-ng.8.in
@@ -110,7 +110,7 @@ It will only show associated clients.
 The minimum number of packets received by an AP before displaying it.
 .TP
 .I -N, --essid
-Filter APs by ESSID. Can be used several times to match a set of ESSID.
+Filter APs by ESSID. May be specified more than once: \(aq\-N AP1 \-N AP2\(aq
 .TP
 .I -R, --essid-regex
 Filter APs by ESSID using a regular expression.

--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -791,7 +791,8 @@ static const char usage[] =
 	"      --netmask <netmask>   : Filter APs by mask\n"
 	"      --bssid     <bssid>   : Filter APs by BSSID,\n"
 	"                              you can pass multiple --bssid options\n"
-	"      --essid     <essid>   : Filter APs by ESSID\n"
+	"      --essid     <essid>   : Filter APs by ESSID,\n"
+	"                              you can pass multiple --essid options\n"
 #if defined HAVE_PCRE2 || defined HAVE_PCRE
 	"      --essid-regex <regex> : Filter APs by ESSID using a regular\n"
 	"                              expression\n"


### PR DESCRIPTION
Fixes #2441 

Passing multiple `--essid` options is already available, see `man airodump-ng`:
```
       -N, --essid
              Filter APs by ESSID. Can be used several times to match a set of ESSID.
```

It is not mentioned in `airodump-ng --help` though so I added it there. Also reworded the manpage so it is consistent with `--bssid` and `--encrypt`:
```
       -t <OPN|WEP|WPA|WPA1|WPA2|WPA3|OWE>, --encrypt <OPN|WEP|WPA|WPA1|WPA2|WPA3|OWE>
              It will only show networks matching the given encryption. Note that WPA is a shortcut for WPA1,  WPA2
              and WPA3. May be specified more than once: '-t OPN -t WPA2'

       -d <bssid>, --bssid <bssid>
              It  will  only  show  networks,  matching  the  given  bssid.  May  be  specified more than once: '-d
              0D:F7:E2:61:C6:6D -d 5B:62:A1:83:00:A8'

...

       -N, --essid
              Filter APs by ESSID. May be specified more than once: '-N AP1 -N AP2'

```

Quick test measurements:
```
$ sudo ./airbase-ng -W 1 -X -y -e AP2 wlp0s20f0u1u2 -a 22:22:22:22:22:22
17:18:33  Created tap interface at0
17:18:33  Trying to set MTU on at0 to 1500
17:18:33  Access Point with BSSID 22:22:22:22:22:22 started.
```
```
$ sudo ./airbase-ng -W 1 -X -y -e AP3 wlp0s20f0u1u3 -a 33:33:33:33:33:33 
17:20:42  Created tap interface at1
17:20:42  Trying to set MTU on at1 to 1500
17:20:42  Access Point with BSSID 33:33:33:33:33:33 started.
```
```
$ sudo ./airodump-ng wlan0mon --essid AP2 --essid AP3
 CH 14 ][ Elapsed: 6 s ][ 2023-02-14 17:21 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH ESSID

 22:22:22:22:22:22  -11       29        0    0   1   54   WEP  WEP         AP2                                       
 33:33:33:33:33:33  -10       28        0    0   1   54   WEP  WEP         AP3
```