### PR TITLE
airodump-ng: keep selected sorting after pressing TAB

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -573,13 +573,11 @@ static THREAD_ENTRY(input_thread)
 				snprintf(lopt.message,
 						 sizeof(lopt.message),
 						 "][ enabled AP selection");
-				lopt.sort_by = SORT_BY_NOTHING;
 			}
 			else
 			{
 				lopt.en_selection_direction = selection_direction_no;
 				lopt.p_selected_ap = NULL;
-				lopt.sort_by = SORT_BY_NOTHING;
 				snprintf(lopt.message,
 						 sizeof(lopt.message),
 						 "][ disabled selection");


### PR DESCRIPTION
Fixes #734

Currently the sorting algorithm is set to SORT_BY_NOTHING after pressing TAB. Now this has been removed so the previously selected sorting algorithm is still getting applied when the user presses TAB and starts scrolling through the AP list.