### PR TITLE
airodump-ng: add -z (show only unassociated clients)

### DIFF
--- a/manpages/airodump-ng.8.in
+++ b/manpages/airodump-ng.8.in
@@ -104,7 +104,10 @@ It will only show networks, matching the given bssid. May be specified more than
 It will only show networks, matching the given bssid ^ netmask combination. Need \-\-bssid (or \-d) to be specified.
 .TP
 .I -a
-It will only show associated clients.
+It will only show associated clients. Using in combination with -z won't display any of the stations.
+.TP
+.I -z
+It will only show unassociated clients. Using in combination with -a won't display any of the stations.
 .TP
 .I -n <int>, --min-packets <int>
 The minimum number of packets received by an AP before displaying it.

--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -182,6 +182,7 @@ static struct local_options
 	int * own_frequencies; /* custom frequency list  */
 
 	int asso_client; /* only show associated clients */
+	int unasso_client; /* only show unassociated clients */
 
 	unsigned char wpa_bssid[6]; /* the wpa handshake bssid   */
 	char message[512];
@@ -353,7 +354,9 @@ static void color_on(void)
 				continue;
 			}
 
-			if (!memcmp(ap_cur->bssid, BROADCAST, 6) && lopt.asso_client)
+			if (((memcmp(ap_cur->bssid, BROADCAST, 6) == 0) && lopt.asso_client)
+				|| ((memcmp(ap_cur->bssid, BROADCAST, 6) != 0)
+					&& lopt.unasso_client))
 			{
 				st_cur = st_cur->prev;
 				continue;
@@ -796,7 +799,8 @@ static const char usage[] =
 	"      --essid-regex <regex> : Filter APs by ESSID using a regular\n"
 	"                              expression\n"
 #endif
-	"      -a                    : Filter unassociated clients\n"
+	"      -a                    : Filter out unassociated clients\n"
+	"      -z                    : Filter out associated clients\n"
 	"\n"
 	"  By default, airodump-ng hops on 2.4GHz channels.\n"
 	"  You can make it capture on other/specific channel(s) by using:\n"
@@ -4183,7 +4187,10 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 					continue;
 				}
 
-				if (!memcmp(ap_cur->bssid, BROADCAST, 6) && lopt.asso_client)
+				if (((memcmp(ap_cur->bssid, BROADCAST, 6) == 0)
+					 && lopt.asso_client)
+					|| ((memcmp(ap_cur->bssid, BROADCAST, 6) != 0)
+						&& lopt.unasso_client))
 				{
 					st_cur = st_cur->prev;
 					continue;
@@ -5981,6 +5988,7 @@ int main(int argc, char * argv[])
 	opt.prefix = NULL;
 	lopt.f_encrypt = 0;
 	lopt.asso_client = 0;
+	lopt.unasso_client = 0;
 	lopt.f_essid = NULL;
 	lopt.f_essid_count = 0;
 	lopt.active_scan_sim = 0;
@@ -6114,12 +6122,12 @@ int main(int argc, char * argv[])
 	{
 		option_index = 0;
 
-		option
-			= getopt_long(argc,
-						  argv,
-						  "b:c:egiw:s:t:u:m:d:N:R:aHDB:Ahf:r:EC:o:x:MUI:WK:n:T",
-						  long_options,
-						  &option_index);
+		option = getopt_long(
+			argc,
+			argv,
+			"b:c:egiw:s:t:u:m:d:N:R:azHDB:Ahf:r:EC:o:x:MUI:WK:n:T",
+			long_options,
+			&option_index);
 
 		if (option < 0) break;
 
@@ -6183,6 +6191,11 @@ int main(int argc, char * argv[])
 			case 'a':
 
 				lopt.asso_client = 1;
+				break;
+
+			case 'z':
+
+				lopt.unasso_client = 1;
 				break;
 
 			case 'A':


### PR DESCRIPTION
Fixes #1033 (when both `-a` and `-z` are supplied, no client is displayed)
Fixes #1262

Added `-z` to show only unassociated clients. Updated `man airodump-ng` and `airodump-ng --help` also:

```
$ man manpages/airodump-ng.8.in
...
       -a     It will only show associated clients.

       -z     It will only show unassociated clients.
...
```
```
$ ./airodump-ng --help
...
      -a                    : Filter unassociated clients
      -z                    : Filter associated clients
...
```

Test measurements:
```
$ sudo ./airodump-ng wlan0mon      
...
 BSSID              STATION            PWR   Rate    Lost    Frames  Notes  Probes

 XX:XX:XX:XX:XX:XX  XX:XX:XX:XX:XX:XX  -75    0 - 1     13        6                                                   
 XX:XX:XX:XX:XX:XX  XX:XX:XX:XX:XX:XX  -87    0 - 1      5        3                                                   
 (not associated)   XX:XX:XX:XX:XX:XX  -73    0 - 5      0        1                                                   
 (not associated)   XX:XX:XX:XX:XX:XX  -83    0 - 1      0        2         <probe> 
```
```
$ sudo ./airodump-ng wlan0mon -a
...
 BSSID              STATION            PWR   Rate    Lost    Frames  Notes  Probes

 XX:XX:XX:XX:XX:XX  XX:XX:XX:XX:XX:XX  -87    0 - 1      1        2                                                   
 XX:XX:XX:XX:XX:XX  XX:XX:XX:XX:XX:XX  -69    0 - 1     16       22         <probe>
```

```
$ sudo ./airodump-ng wlan0mon -z
...
 BSSID              STATION            PWR   Rate    Lost    Frames  Notes  Probes

 (not associated)   XX:XX:XX:XX:XX:XX  -89    0 - 1      0        1         <probe>
```

```
$ sudo ./airodump-ng wlan0mon -a -z
...
 BSSID              STATION            PWR   Rate    Lost    Frames  Notes  Probes

                                                                                   
```