### PR TITLE
airodump-ng: fix coloring of unassociated stations when '-n' is used

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -320,8 +320,15 @@ static void color_on(void)
 
 	while (ap_cur != NULL)
 	{
-		if (ap_cur->nb_pkt < lopt.min_pkts
-			|| time(NULL) - ap_cur->tlast > lopt.berlin)
+		// Don't filter unassociated stations by number of packets
+		if (memcmp(ap_cur->bssid, BROADCAST, 6) != 0
+			&& ap_cur->nb_pkt < lopt.min_pkts)
+		{
+			ap_cur = ap_cur->prev;
+			continue;
+		}
+
+		if (time(NULL) - ap_cur->tlast > lopt.berlin)
 		{
 			ap_cur = ap_cur->prev;
 			continue;


### PR DESCRIPTION
Fixes #2453 

Fixed the coloring of unassociated stations when `-n` filter is used. Refer to the linked issue for more information.