### PR TITLE
airodump-ng: move '-n' to the filters in usage info, add default value of '-n' to usage info and manpage

### DIFF
--- a/manpages/airodump-ng.8.in
+++ b/manpages/airodump-ng.8.in
@@ -110,7 +110,7 @@ It will only show associated stations. Using in combination with -z won't displa
 It will only show unassociated stations. Using in combination with -a won't display any of the stations.
 .TP
 .I -n <int>, --min-packets <int>
-The minimum number of packets received by an AP before displaying it.
+The minimum number of packets received by an AP before displaying it. Default value: 2.
 .TP
 .I -N, --essid
 Filter APs by ESSID. May be specified more than once: \(aq\-N AP1 \-N AP2\(aq

--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -784,8 +784,6 @@ static const char usage[] =
 	"      --write-interval\n"
 	"                  <seconds> : Output file(s) write interval in seconds\n"
 	"      --background <enable> : Override background detection.\n"
-	"      -n              <int> : Minimum AP packets recv'd before\n"
-	"                              for displaying it\n"
 	"\n"
 	"  Filter options:\n"
 	"      --encrypt   <suite>   : Filter APs by cipher suite,\n"
@@ -799,6 +797,8 @@ static const char usage[] =
 	"      --essid-regex <regex> : Filter APs by ESSID using a regular\n"
 	"                              expression\n"
 #endif
+	"      -n              <int> : Minimum AP packets recv'd before\n"
+	"                              displaying it\n"
 	"      -a                    : Filter out unassociated stations\n"
 	"      -z                    : Filter out associated stations\n"
 	"\n"

--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -798,7 +798,7 @@ static const char usage[] =
 	"                              expression\n"
 #endif
 	"      -n              <int> : Minimum AP packets recv'd before\n"
-	"                              displaying it\n"
+	"                              displaying it (default: 2)\n"
 	"      -a                    : Filter out unassociated stations\n"
 	"      -z                    : Filter out associated stations\n"
 	"\n"


### PR DESCRIPTION
Added default value of option `-n` to usage info and manpage of `airodump-ng`. Moved the option to the other filter options in usage info, as it was already there in `man airodump-ng`:

```
       Filter options:

...
       -n <int>, --min-packets <int>
              The minimum number of packets received by an AP before displaying it.
...
```

There was also a typo which I fixed:

Before:
```
      -n              <int> : Minimum AP packets recv'd before
                              for displaying it
```
After:
```
      -n              <int> : Minimum AP packets recv'd before
                              displaying it (default: 2)
```