### PR TITLE
airodump-ng: add support for '--ignore-other-chans' option

### DIFF
--- a/manpages/airodump-ng.8.in
+++ b/manpages/airodump-ng.8.in
@@ -41,6 +41,9 @@ Time before removing the AP/client from the screen when no more frames are recei
 .I -c <channel>[,<channel>[,...]], --channel <channel>[,<channel>[,...]]
 Indicate the channel(s) to listen to. By default airodump-ng hops on all 2.4GHz channels.
 .TP
+.I -O, --ignore-other-chans
+Ignore access points on channels other than the selected one(s). Requires \-\-channel (or \-c).
+.TP
 .I -C <freq>[,<freq>[,...]]
 Indicates the frequencies to listen to. By default airodump-ng hops on all 2.4GHz channels.
 .TP


### PR DESCRIPTION
Fixes #1329

Added `--ignore-other-chans` option (`--ignore-other-channels` would be too long and the whole `airodump-ng --help` info should be shifted to maintain aligned indentation). Updated `airodump-ng --help` and `man airodump-ng` also.

Test measurements:

```
$ sudo ./airodump-ng wlan0mon --ignore-other-chans                         
Notice: specify "--ignore-other-chans" with "--channel"
"/home/gemesa/git-repos/aircrack-ng/.libs/airodump-ng --help" for help.
```

```
$ sudo ./airodump-ng wlan0mon -c 1-3
```
![image](https://user-images.githubusercontent.com/59890178/219874983-f352cf9a-29ad-4e9d-bc46-30c778a17921.png)

```
$ sudo ./airodump-ng wlan0mon --ignore-other-chans -c 1-3
```

![image](https://user-images.githubusercontent.com/59890178/219875066-4f5a30ae-bc5d-4577-87c3-18d7125f5df6.png)
