### PR TITLE
airodump-ng: fix marking when color is enabled

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -277,6 +277,7 @@ static struct local_options
 	int relative_time; /* read PCAP in psuedo-real-time */
 
 	int color_on;
+	int color;
 } lopt;
 
 static void resetSelection(void)
@@ -315,11 +316,8 @@ static void color_on(void)
 {
 	struct AP_info * ap_cur;
 	struct ST_info * st_cur;
-	int color = 2;
 	int i;
 	int match;
-
-	color_off();
 
 	ap_cur = lopt.ap_end;
 
@@ -413,7 +411,7 @@ static void color_on(void)
 				continue;
 			}
 
-			if (color > TEXT_MAX_COLOR) color++;
+			if (lopt.color > TEXT_MAX_COLOR) lopt.color++;
 
 			if (!ap_cur->marked)
 			{
@@ -421,7 +419,7 @@ static void color_on(void)
 				if (!memcmp(ap_cur->bssid, BROADCAST, 6))
 					ap_cur->marked_color = 1;
 				else
-					ap_cur->marked_color = color++;
+					ap_cur->marked_color = lopt.color++;
 			}
 
 			st_cur = st_cur->prev;
@@ -471,6 +469,8 @@ static THREAD_ENTRY(input_thread)
 			color_off();
 			snprintf(lopt.message, sizeof(lopt.message), "][ color off");
 			lopt.color_on = 0;
+			// reset color (if color is enabled again it starts again from green)
+			lopt.color = TEXT_GREEN;
 		}
 
 		if (keycode == KEY_s)
@@ -6115,6 +6115,7 @@ int main(int argc, char * argv[])
 	lopt.min_rxq = -1;
 	lopt.relative_time = 0;
 	lopt.color_on = 0;
+	lopt.color = TEXT_GREEN;
 #ifdef CONFIG_LIBNL
 	lopt.htval = CHANNEL_NO_HT;
 #endif


### PR DESCRIPTION
Fixes #2459 

Fixed marking when color is enabled: this means we can now mark APs ('tab' --> arrow keys --> 'm') when color is enabled.

Background of the suggested changes:
- removed the `color_off()` call from the definition of `color_on()`, this is necessary because previously this cleared the marked APs constantly when color is enabled
- replaced the initial value (`2`) of `color`  with `TEXT_GREEN` for readability (`#define TEXT_GREEN 2`)
- moved `color` to local options (`lopt`):
  - to have static lifetime, without this after enabling color, the newly added clients always get the green color
  - to be able to reset it to green, this way the coloring starts from green again if color is enabled then disabled then enabled again

I did some initial investigation before and documented it under the linked issue, refer to that for more information.