### PR TITLE
airodump-ng: add support for '--exclude-bssid' option

### DIFF
--- a/manpages/airodump-ng.8.in
+++ b/manpages/airodump-ng.8.in
@@ -101,10 +101,13 @@ Removes the message that says \(aqfixed channel <interface>: -1\(aq.
 It will only show networks matching the given encryption. Note that WPA is a shortcut for WPA1, WPA2 and WPA3. May be specified more than once: \(aq\-t OPN \-t WPA2\(aq
 .TP
 .I -d <bssid>, --bssid <bssid>
-It will only show networks, matching the given bssid. May be specified more than once: \(aq\-d 0D:F7:E2:61:C6:6D \-d 5B:62:A1:83:00:A8\(aq
+It will only show networks, matching the given BSSID. May be specified more than once: \(aq\-d 0D:F7:E2:61:C6:6D \-d 5B:62:A1:83:00:A8\(aq
+.TP
+.I -X <bssid>, --exclude-bssid <bssid>
+It will show all networks, except the one matching the given BSSID. May be specified more than once: \(aq\-X 0D:F7:E2:61:C6:6D \-X 5B:62:A1:83:00:A8\(aq
 .TP
 .I -m <mask>, --netmask <mask>
-It will only show networks, matching the given bssid ^ netmask combination. Need \-\-bssid (or \-d) to be specified.
+It will only show networks, matching the given BSSID ^ netmask combination. Need \-\-bssid (or \-d) to be specified.
 .TP
 .I -a
 It will only show associated stations. Using in combination with -z won't display any of the stations.

--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -141,6 +141,7 @@ static struct local_options
 	struct oui * manufList;
 
 	pMAC_t rBSSID;
+	pMAC_t rXBSSID;
 	unsigned char prev_bssid[6];
 	char ** f_essid;
 	int f_essid_count;
@@ -842,6 +843,10 @@ static const char usage[] =
 	"      --netmask <netmask>   : Filter APs by mask\n"
 	"      --bssid     <bssid>   : Filter APs by BSSID,\n"
 	"                              you can pass multiple --bssid options\n"
+	"      --exclude-bssid\n"
+	"                    <bssid> : Similar to --bssid but excludes the AP,\n"
+	"                              you can pass multiple --exclude-bssid "
+	"options\n"
 	"      --essid     <essid>   : Filter APs by ESSID,\n"
 	"                              you can pass multiple --essid options\n"
 #if defined HAVE_PCRE2 || defined HAVE_PCRE
@@ -893,24 +898,46 @@ static int is_filtered_netmask(const uint8_t * bssid)
 	unsigned char mac2[6];
 	int i;
 	pMAC_t cur = lopt.rBSSID;
+	pMAC_t curx = lopt.rXBSSID;
 	unsigned char match = 0;
 
-	while (cur->next != NULL)
+	if (getMACcount(lopt.rXBSSID) > 0)
 	{
-		cur = cur->next;
-		for (i = 0; i < 6; i++)
+		while (curx->next != NULL)
 		{
-			mac1[i] = bssid[i] & opt.f_netmask[i];
-			mac2[i] = cur->mac[i] & opt.f_netmask[i];
-		}
+			curx = curx->next;
+			for (i = 0; i < 6; i++)
+			{
+				mac1[i] = bssid[i] & opt.f_netmask[i];
+				mac2[i] = curx->mac[i] & opt.f_netmask[i];
+			}
 
-		if (memcmp(mac1, mac2, 6) == 0)
-		{
-			match = 1;
-			break;
+			if (memcmp(mac1, mac2, 6) == 0)
+			{
+				return (1);
+			}
 		}
 	}
-	if (match != 1) return (1);
+
+	if (getMACcount(lopt.rBSSID) > 0)
+	{
+		while (cur->next != NULL)
+		{
+			cur = cur->next;
+			for (i = 0; i < 6; i++)
+			{
+				mac1[i] = bssid[i] & opt.f_netmask[i];
+				mac2[i] = cur->mac[i] & opt.f_netmask[i];
+			}
+
+			if (memcmp(mac1, mac2, 6) == 0)
+			{
+				match = 1;
+				break;
+			}
+		}
+		if (match != 1) return (1);
+	}
 
 	return (0);
 }
@@ -1311,6 +1338,7 @@ static int dump_add_packet(unsigned char * h80211,
 	int weight[16];
 	int num_xor = 0;
 	pMAC_t cur = lopt.rBSSID;
+	pMAC_t curx = lopt.rXBSSID;
 	unsigned char match = 0;
 
 	struct AP_info * ap_cur = NULL;
@@ -1359,7 +1387,7 @@ static int dump_add_packet(unsigned char * h80211,
 			abort();
 	}
 
-	if (getMACcount(lopt.rBSSID) > 0)
+	if ((getMACcount(lopt.rBSSID) > 0) || (getMACcount(lopt.rXBSSID) > 0))
 	{
 		if (memcmp(opt.f_netmask, NULL_MAC, 6) != 0)
 		{
@@ -1367,16 +1395,31 @@ static int dump_add_packet(unsigned char * h80211,
 		}
 		else
 		{
-			while (cur->next != NULL)
+			if (getMACcount(lopt.rXBSSID) > 0)
 			{
-				cur = cur->next;
-				if (memcmp(cur->mac, bssid, 6) == 0)
+				while (curx->next != NULL)
 				{
-					match = 1;
-					break;
+					curx = curx->next;
+					if (memcmp(curx->mac, bssid, 6) == 0)
+					{
+						return (1);
+					}
 				}
 			}
-			if (match != 1) return (1);
+
+			if (getMACcount(lopt.rBSSID) > 0)
+			{
+				while (cur->next != NULL)
+				{
+					cur = cur->next;
+					if (memcmp(cur->mac, bssid, 6) == 0)
+					{
+						match = 1;
+						break;
+					}
+				}
+				if (match != 1) return (1);
+			}
 		}
 	}
 
@@ -5998,6 +6041,7 @@ int main(int argc, char * argv[])
 		   {"cswitch", 1, 0, 's'},
 		   {"netmask", 1, 0, 'm'},
 		   {"bssid", 1, 0, 'd'},
+		   {"exclude-bssid", 1, 0, 'X'},
 		   {"essid", 1, 0, 'N'},
 		   {"essid-regex", 1, 0, 'R'},
 		   {"channel", 1, 0, 'c'},
@@ -6154,6 +6198,9 @@ int main(int argc, char * argv[])
 	lopt.rBSSID = (pMAC_t) malloc(sizeof(struct MAC_list));
 	ALLEGE(lopt.rBSSID != NULL);
 	memset(lopt.rBSSID, 0, sizeof(struct MAC_list));
+	lopt.rXBSSID = (pMAC_t) malloc(sizeof(struct MAC_list));
+	ALLEGE(lopt.rXBSSID != NULL);
+	memset(lopt.rXBSSID, 0, sizeof(struct MAC_list));
 	memset(opt.f_netmask, '\x00', 6);
 	memset(lopt.wpa_bssid, '\x00', 6);
 
@@ -6215,7 +6262,7 @@ int main(int argc, char * argv[])
 		option = getopt_long(
 			argc,
 			argv,
-			"b:c:Oegiw:s:t:u:m:d:N:R:azHDB:Ahf:r:EC:o:x:MUI:WK:n:p:q:T",
+			"b:c:Oegiw:s:t:u:m:d:X:N:R:azHDB:Ahf:r:EC:o:x:MUI:WK:n:p:q:T",
 			long_options,
 			&option_index);
 
@@ -6530,7 +6577,22 @@ int main(int argc, char * argv[])
 				}
 				else
 				{
-					printf("Notice: invalid bssid\n");
+					printf("Error: invalid BSSID\n");
+					printf("\"%s --help\" for help.\n", argv[0]);
+
+					return (EXIT_FAILURE);
+				}
+				break;
+
+			case 'X':
+
+				if (getmac(optarg, 1, mac) == 0)
+				{
+					addMAC(lopt.rXBSSID, mac);
+				}
+				else
+				{
+					printf("Error: invalid BSSID\n");
 					printf("\"%s --help\" for help.\n", argv[0]);
 
 					return (EXIT_FAILURE);
@@ -6799,9 +6861,11 @@ int main(int argc, char * argv[])
 	if (argc - optind == 1) lopt.s_iface = argv[argc - 1];
 
 	if ((memcmp(opt.f_netmask, NULL_MAC, 6) != 0)
-		&& (getMACcount(lopt.rBSSID) == 0))
+		&& (getMACcount(lopt.rBSSID) == 0)
+		&& (getMACcount(lopt.rXBSSID) == 0))
 	{
-		printf("Notice: specify bssid \"--bssid\" with \"--netmask\"\n");
+		printf("Error: specify \"--bssid\" or \"--exclude-bssid\" with "
+			   "\"--netmask\"\n");
 		printf("\"%s --help\" for help.\n", argv[0]);
 		return (EXIT_FAILURE);
 	}
@@ -7641,6 +7705,8 @@ int main(int argc, char * argv[])
 
 	flushMACs(lopt.rBSSID);
 	free(lopt.rBSSID);
+	flushMACs(lopt.rXBSSID);
+	free(lopt.rXBSSID);
 
 	reset_term();
 	show_cursor();


### PR DESCRIPTION
Fixes #796

Added support for `--exclude-bssid` or `-X` option. Updated `airodump-ng --help` and `man airodump-ng` also. Replaced some BSSID related `Notice: ...` messages with `Error: ...`. The second part in the linked issue is already implemented (`--essid-regex`).

Test measurements (always sorted by BSSID):

```
$ sudo ./airodump-ng wlan0mon -c 1
```

![image](https://user-images.githubusercontent.com/59890178/220412264-76b4bcfa-e39c-4039-9c56-94da0c1f8278.png)


```
$ sudo ./airodump-ng wlan0mon -c 1 -d D2:21:F9:00:00:00 --netmask FF:FF:FF:00:00:00
```

![image](https://user-images.githubusercontent.com/59890178/220412558-93dbf3a1-5594-4726-bdf1-5b0ae4f0689c.png)


```
$ sudo ./airodump-ng wlan0mon -c 1 -X D2:21:F9:00:00:00 --netmask FF:FF:FF:00:00:00
```

![image](https://user-images.githubusercontent.com/59890178/220412880-4b09d65f-1bcb-4d83-ad41-bd8ab33f0640.png)

```
$ sudo ./airodump-ng wlan0mon -c 1 -d D2:21:F9:XX:XX:XX -d 22:E8:29:XX:XX:XX
```

![image](https://user-images.githubusercontent.com/59890178/220414110-67df966a-db26-401e-9c6c-836a2840429d.png)

```
$ sudo ./airodump-ng wlan0mon -c 1 -X D2:21:F9:XX:XX:XX -X D2:21:F9:XX:XX:XX -X D2:21:F9:XX:XX:XX -X D2:21:F9:XX:XX:XX
```

![image](https://user-images.githubusercontent.com/59890178/220414731-34a5db76-ce0c-4d75-9e87-3c191bdb920a.png)

```
$ sudo ./airodump-ng wlan0mon --netmask FF:FF:FF:00:00:00                                                        
Error: specify "--bssid" or "--exclude-bssid" with "--netmask"
"/home/gemesa/git-repos/aircrack-ng/.libs/airodump-ng --help" for help.
```