### PR TITLE
airodump-ng: add missing args for -N and -R in manpage

### DIFF
--- a/manpages/airodump-ng.8.in
+++ b/manpages/airodump-ng.8.in
@@ -121,10 +121,10 @@ Filter out APs with PWR less than the specified value (default value: -120).
 .I -q <int>, --min-rxq <int>
 Filter out APs with RXQ less than the specified value (default value: 0). Valid range: 0..100. Requires --channel (or -c) or -C.
 .TP
-.I -N, --essid
+.I -N <essid>, --essid <essid>
 Filter APs by ESSID. May be specified more than once: \(aq\-N AP1 \-N AP2\(aq
 .TP
-.I -R, --essid-regex
+.I -R <regex>, --essid-regex <regex>
 Filter APs by ESSID using a regular expression.
 .SH INTERACTION
 .PP


### PR DESCRIPTION
Added missing arguments of `--essid` and `--essid-regex` to `man airodump-ng`. They were already present in the usage info:

```
$ ./airodump-ng --help
...
      --essid     <essid>   : Filter APs by ESSID,
                              you can pass multiple --essid options
      --essid-regex <regex> : Filter APs by ESSID using a regular
                              expression
...
```

Manpage before:
```
$ man manpages/airodump-ng.8.in
...
       -N, --essid
              Filter APs by ESSID. Can be used several times to match a set of ESSID.

       -R, --essid-regex
              Filter APs by ESSID using a regular expression.
...
```

Manpage after:
```
$ man manpages/airodump-ng.8.in
...
       -N <essid>, --essid <essid>
              Filter APs by ESSID. May be specified more than once: '-N AP1 -N AP2'

       -R <regex>, --essid-regex <regex>
              Filter APs by ESSID using a regular expression.
...

```