### PR TITLE
airodump-ng: add missing -f option to manpage

### DIFF
--- a/manpages/airodump-ng.8.in
+++ b/manpages/airodump-ng.8.in
@@ -35,6 +35,9 @@ Prints ACK/CTS/RTS statistics. Helps in debugging and general injection optimiza
 .I -h
 Hides known stations for \-\-showack.
 .TP
+.I -f <msecs>
+Time in milliseconds between hopping channels.
+.TP
 .I --berlin <secs>
 Time before removing the AP/client from the screen when no more frames are received (Default: 120 seconds). See airodump-ng source for the history behind this option ;).
 .TP


### PR DESCRIPTION
Added missing option `-f` to `man airodump-ng`. It was already present in the usage info:

```
$ ./airodump-ng --help
...
      -h                    : Hides known stations for --showack
      -f            <msecs> : Time in ms between hopping channels
      --berlin       <secs> : Time before removing the AP/client
                              from the screen when no more packets
                              are received (Default: 120 seconds)
...
```

Manpage before:

```
$ man manpages/airodump-ng.8.in
...
       -h     Hides known stations for --showack.

       --berlin <secs>
              Time  before  removing  the  AP/client from the screen when no more frames are received (Default: 120
              seconds). See airodump-ng source for the history behind this option ;).
...
```

Manpage after:

```
$ man manpages/airodump-ng.8.in
...
       -h     Hides known stations for --showack.

       -f <msecs>
              Time in ms between hopping channels.

       --berlin <secs>
              Time  before  removing  the  AP/client from the screen when no more frames are received (Default: 120
              seconds). See airodump-ng source for the history behind this option ;).
...
```