### PR TITLE
airodump-ng: return EXIT_SUCCESS in case of --help

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -6740,7 +6740,7 @@ int main(int argc, char * argv[])
 
 			case 'H':
 				airodump_usage();
-				return (EXIT_FAILURE);
+				return (EXIT_SUCCESS);
 
 			case 'x':
 


### PR DESCRIPTION
When running `airodump-ng --help` `EXIT_SUCCESS` should be the exit code not `EXIT_FAILURE`. Now this is fixed.

Before:
```
$ ./airodump-ng --help
...
$ echo $?             
1
```

After:
```
$ ./airodump-ng --help
...
$ echo $?             
0
```