### PR TITLE
airodump-ng: do not display station column titles when -a + -z are specified

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -4205,7 +4205,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 		CHECK_END_OF_SCREEN();
 	}
 
-	if (lopt.show_sta)
+	if (lopt.show_sta && !(lopt.asso_station && lopt.unasso_station))
 	{
 		strlcpy(strbuf,
 				" BSSID              STATION "


### PR DESCRIPTION
Follow-up of #2448

Added a message to notify user when both `-a` and `-z` are specified:

```
$ sudo ./airodump-ng wlp0s20f0u1 -a -z
 CH 14 ][ Elapsed: 0 s ][ 2023-02-27 22:18 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH ESSID
                   
 XX:XX:XX:XX:XX:XX  -83        6        0    0   1  130   WPA2 CCMP   PSK  <ESSID>                       
 XX:XX:XX:XX:XX:XX  -38       17        0    0   1  130   WPA2 CCMP   PSK  <ESSID>                                
 XX:XX:XX:XX:XX:XX  -77        6        0    0   1  130   WPA2 CCMP   PSK  <ESSID>                             

 BSSID              STATION            PWR   Rate    Lost    Frames  Notes  Probes

 All stations are filtered out.
```