### PR TITLE
workflows: add missing *.ymls to ignore paths

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,6 +63,8 @@ on:
       - '.github/workflows/gentoo.yml'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/workflows/almalinux.yml'
+      - '.github/workflows/alpine.yml'
+      - '.github/workflows/check-release-ready.yml'
       - '.github/workflows/coverity.yml'
       - '.github/workflows/docker.yml'
       - '.github/workflows/docker-release.yml'

--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -62,6 +62,8 @@ on:
       - '.github/workflows/gentoo.yml'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/workflows/almalinux.yml'
+      - '.github/workflows/alpine.yml'
+      - '.github/workflows/check-release-ready.yml'
       - '.github/workflows/coverity.yml'
       - '.github/workflows/docker.yml'
       - '.github/workflows/docker-release.yml'


### PR DESCRIPTION
While working on #2474 I noticed modifying `alpine.yml` triggers `linux.yml` and `pvs-studio.yml` CIs. Now this is fixed and `check-release-ready.yml` is also added to the ignore paths.