### PR TITLE
test-circular-buffer: fix pointer sign mismatch error

### DIFF
--- a/test/unit/test-circular-buffer.c
+++ b/test/unit/test-circular-buffer.c
@@ -99,7 +99,7 @@ static void test_cbuf_multibyte_compare_buffer(void ** state)
 	assert_int_equal(nb_elements, circular_buffer_size(cbuf));
 	assert_false(circular_buffer_is_empty(cbuf));
 	assert_true(circular_buffer_is_full(cbuf));
-	assert_string_equal("a1234567b1234567", buffer);
+	assert_memory_equal("a1234567b1234567", buffer, size);
 
 	// END
 #undef size


### PR DESCRIPTION
Fixes #2465 

Fixed the sign mismatch error mentioned in the linked issue. Also ran the action in my fork repo, see results [here](https://github.com/gemesa/aircrack-ng/actions/runs/4291264921/jobs/7476236439). I used `assert_memory_equal()` instead of `assert_string_equal()` similarly to other circular buffer unit test like this one:

```
static void test_cbuf_multibyte_compare_buffer_of_short_put(void ** state)
{
	(void) state;

	// GIVEN
#define	nb_elements 2
#define	elementSize 8
#define	size (nb_elements * elementSize)
	uint8_t buffer[size + 1];
	buffer[size] = 0;
	cbuf_handle_t cbuf = circular_buffer_init(buffer, size, elementSize);

	// WHEN
	circular_buffer_put(cbuf, "a123", 4);
	circular_buffer_put(cbuf, "b1234567", 8);

	// THEN
	assert_int_equal(nb_elements, circular_buffer_size(cbuf));
	assert_false(circular_buffer_is_empty(cbuf));
	assert_true(circular_buffer_is_full(cbuf));
	assert_memory_equal("a123\0\0\0\0b1234567", buffer, size);

	// END
#undef size
#undef elementSize
#undef nb_elements
	circular_buffer_free(cbuf);
}
```