### PR TITLE
workflows: install git in DragonFlyBSD CI (required by evalrev)

### DIFF
--- a/.github/workflows/dragonflybsd.yml
+++ b/.github/workflows/dragonflybsd.yml
@@ -133,7 +133,7 @@ jobs:
           envs: 'LANG TZ MAKE'
           usesh: true
           prepare: |
-            pkg install -y pkgconf shtool libtool ${{ matrix.compiler.cc }} automake autoconf pcre2 sqlite3 gmake cmocka
+            pkg install -y git pkgconf shtool libtool ${{ matrix.compiler.cc }} automake autoconf pcre2 sqlite3 gmake cmocka
           run: |
             export CC="${{ matrix.compiler.cc }}"
             export CXX="${{ matrix.compiler.cxx }}"


### PR DESCRIPTION
`git` is required by `evalrev` but is missing currently from the DragonFlyBSD CI (see [this job](https://github.com/aircrack-ng/aircrack-ng/actions/runs/4294009427/jobs/7482446070) for example) so I added it to the install dependencies. [Here](https://github.com/gemesa/aircrack-ng/actions/runs/4295816853/jobs/7486735035) is a test job I run in my fork repo after adding `git`.

```
autoreconf
  make: don't know how to make distclean. Stop
  autoreconf2.71: export WARNINGS=
  autoreconf2.71: Entering directory '.'
  autoreconf2.71: configure.ac: not using Gettext
  autoreconf2.71: running: aclocal --force -I build/m4/stubs -I build/m4
  /Users/runner/work/aircrack-ng/aircrack-ng/evalrev: git: not found
  /Users/runner/work/aircrack-ng/aircrack-ng/evalrev: git: not found
  autoreconf2.71: configure.ac: tracing
  /Users/runner/work/aircrack-ng/aircrack-ng/evalrev: git: not found
  /Users/runner/work/aircrack-ng/aircrack-ng/evalrev: git: not found
```