### PR TITLE
workflows: replace sysctl with getconf in NetBSD CI

### DIFF
--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -136,7 +136,7 @@ jobs:
           run: |
             export CC="${{ matrix.compiler.cc }}"
             export CXX="${{ matrix.compiler.cxx }}"
-            alias nproc='sysctl -n hw.ncpu'
+            alias nproc='getconf NPROCESSORS_ONLN'
             CPUS=$(nproc)
             git config --global --add safe.directory /Users/runner/work/aircrack-ng/aircrack-ng
             echo "::group::make distclean"


### PR DESCRIPTION
Fixes #2478 

Replaced `sysctl` with `getconf` according to [this](https://stackoverflow.com/questions/45181115/portable-way-to-find-the-number-of-processors-cpus-in-a-shell-script). The only difference is that the variable is `NPROCESSORS_ONLN` instead of `_NPROCESSORS_ONLN`. I dont know why `sysctl` is missing but I dont think it is worth investigating. Replacing it is a quick and easy fix. I ran a [test job](https://github.com/gemesa/aircrack-ng/actions/runs/4296321182/jobs/7487888482) also in my fork repo.