### PR TITLE
airodump-ng: fix displaying -M and -W columns

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -3580,7 +3580,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 	struct AP_info * ap_cur;
 	struct ST_info * st_cur;
 	struct NA_info * na_cur;
-	int columns_ap = 83;
+	int columns_ap = 84;
 	int columns_sta = 74;
 	ssize_t len;
 
@@ -3766,22 +3766,22 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 			strlcat(strbuf, "WPS   ", sizeof(strbuf));
 			if (ws_col > (columns_ap - 4))
 			{
-				const size_t n_strbuf = strlen(strbuf);
-				memset(strbuf + n_strbuf, 32, sizeof(strbuf) - n_strbuf - 1);
-				snprintf(strbuf + columns_ap + lopt.maxsize_wps_seen - 5,
-						 8,
+				memset(strbuf + columns_ap, ' ', sizeof(strbuf) - columns_ap);
+				snprintf(strbuf + columns_ap - strlen("ESSID")
+							 + lopt.maxsize_wps_seen
+							 + strlen(" "),
+						 6,
 						 "%s",
-						 "  ESSID");
+						 "ESSID");
 				if (lopt.show_manufacturer)
 				{
 					memset(strbuf + columns_ap + lopt.maxsize_wps_seen + 1,
-						   32,
-						   sizeof(strbuf) - columns_ap - lopt.maxsize_wps_seen
-							   - 1);
+						   ' ',
+						   sizeof(strbuf) - columns_ap - lopt.maxsize_wps_seen);
 					snprintf(strbuf + columns_ap + lopt.maxsize_wps_seen
 								 + lopt.maxsize_essid_seen
-								 - 4,
-							 15,
+								 - strlen("ESSID"),
+							 13,
 							 "%s",
 							 "MANUFACTURER");
 				}
@@ -3793,12 +3793,12 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 
 			if (lopt.show_manufacturer && (ws_col > (columns_ap - 4)))
 			{
-				// write spaces (32).
-				memset(strbuf + columns_ap, 32, lopt.maxsize_essid_seen - 5);
-				snprintf(strbuf + columns_ap + lopt.maxsize_essid_seen - 7,
-						 15,
+				memset(strbuf + columns_ap, ' ', sizeof(strbuf) - columns_ap);
+				snprintf(strbuf + columns_ap - strlen("ESSID")
+							 + lopt.maxsize_essid_seen,
+						 13,
 						 "%s",
-						 "  MANUFACTURER");
+						 "MANUFACTURER");
 			}
 		}
 		strbuf[ws_col - 1] = '\0';


### PR DESCRIPTION
When `--manufacturer` option is provided to `airodump-ng` the column titles are not displayed properly:

```
$ sudo airodump-ng wlp0s20f0u1 --manufacturer --wps

 CH  2 ][ Elapsed: 0 s ][ 2023-03-03 20:32 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH WPS    ESSI          MANUFACTURER

 XX:XX:XX:XX:XX:XX  -78        2        0    0   9  130   WPA2 CCMP   PSK  2.0    XXXXXXXXXXXXX Compal Broadband Networks, Inc.
```

As you can see `ESSI` is displayed instead of `ESSID`.

```
$ sudo airodump-ng wlp0s20f0u1 --manufacturer

 CH  7 ][ Elapsed: 0 s ][ 2023-03-03 20:34 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH ESSI        MANUFACTURER

 XX:XX:XX:XX:XX:XX  -83        2        0    0   1  130   WPA2 CCMP   PSK  XXXXXXX      Compal Broadband Networks, Inc.
```

As you can see `ESSI` is displayed instead of `ESSID` and `MANUFACTURER` is shifted by one space.

These issues have multiple reasons: `columns_ap` was hardcoded to `83` but the length of this line is `84`:
```
 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH ESSID
```
Also, there were some magic numbers going on (`-1`, `-5`, `-7`, `32`) and some of them were wrong. Not to mention they made the code difficult to read. Now these issues have been fixed.

Test measurements:

```
$ sudo ./airodump-ng wlp0s20f0u1 --wps --manufacturer

 CH 13 ][ Elapsed: 0 s ][ 2023-03-03 20:42 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH WPS    ESSID         MANUFACTURER

 XX:XX:XX:XX:XX:XX  -57        3        0    0   6  195   WPA2 CCMP   PSK Locked  XXXXXXXXXXXXX ARRIS Group, Inc.
```

```
$ sudo ./airodump-ng wlp0s20f0u1 --wps

 CH  7 ][ Elapsed: 0 s ][ 2023-03-03 20:45 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH WPS    ESSID

 XX:XX:XX:XX:XX:XX  -84        2        0    0   1  130   WPA2 CCMP   PSK  2.0    XXXXXXX
```

```
$ sudo ./airodump-ng wlp0s20f0u1 --manufacturer 
 CH 13 ][ Elapsed: 0 s ][ 2023-03-03 20:47 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH ESSID         MANUFACTURER

 XX:XX:XX:XX:XX:XX  -78        2        0    0   6  130   WPA2 CCMP   PSK  XXXXXXXXXXXXX Compal Broadband Networks, Inc.
```

```
$ sudo ./airodump-ng wlp0s20f0u1 --wps --manufacturer -c 1
 CH  1 ][ Elapsed: 0 s ][ 2023-03-03 20:49 ][ Are you sure you want to quit? Press Q again to quit.

 BSSID              PWR RXQ  Beacons    #Data, #/s  CH   MB   ENC CIPHER  AUTH WPS    ESSID          MANUFACTURER

 XX:XX:XX:XX:XX:XX  -86   0        4        2    0   2  195   WPA2 CCMP   PSK  2.0    XXXXXXXXXXXXXX Sagemcom Broadband SAS
```