### PR TITLE
workflows: disable 'copyback' in BSD CIs

### DIFF
--- a/.github/workflows/dragonflybsd.yml
+++ b/.github/workflows/dragonflybsd.yml
@@ -132,6 +132,8 @@ jobs:
         with:
           envs: 'LANG TZ MAKE'
           usesh: true
+          sync: rsync
+          copyback: false
           prepare: |
             pkg install -y git pkgconf shtool libtool ${{ matrix.compiler.cc }} automake autoconf pcre2 sqlite3 gmake cmocka
           run: |

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -132,6 +132,8 @@ jobs:
         with:
           envs: 'LANG TZ MAKE'
           usesh: true
+          sync: rsync
+          copyback: false
           prepare: |
             pkg install -y git pkgconf shtool libtool gcc automake autoconf pcre2 sqlite3 openssl gmake hwloc cmocka
           run: |

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -131,6 +131,8 @@ jobs:
         with:
           envs: 'LANG TZ MAKE'
           usesh: true
+          sync: rsync
+          copyback: false
           prepare: |
             pkg_add git pkgconf libtool gcc7 automake autoconf pcre2 sqlite3 openssl gmake cmocka
           run: |

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -132,6 +132,8 @@ jobs:
         with:
           envs: 'LANG TZ MAKE'
           usesh: true
+          sync: rsync
+          copyback: false
           prepare: |
             pkg_add git pkgconf shtool libtool llvm automake-1.16.5 autoconf-2.71 pcre2 sqlite3 openssl gmake cmocka
           run: |


### PR DESCRIPTION
While investigating why the BSD CIs [fail sometime](https://github.com/aircrack-ng/aircrack-ng/actions/runs/4326875996/jobs/7554834924) I noticed there is an [option](https://github.com/vmactions/freebsd-vm) to disable copying files back from the VM to the host. This is very good because the actions fail exactly in the `Copy files back from the VM` step. Also we do not archive the files anyway so we do not need to copy anything back. This will speed up significantly the BSD CIs as well.