### PR TITLE
readme, installing: remove buildbots

### DIFF
--- a/INSTALLING
+++ b/INSTALLING
@@ -437,24 +437,6 @@ Aircrack-ng is available in most distributions repositories. However, it is not 
 - PVS-Studio static analysis (GitHub actions): https://github.com/aircrack-ng/aircrack-ng/actions/workflows/pvs-studio.yml
 - Coverity Scan static analysis: https://scan.coverity.com/projects/aircrack-ng
 
-=== Buildbots ===
-
-URL: https://buildbot.aircrack-ng.org/
-
-Linux buildbots:
-- CentOS
-- AArch64
-- Kali Linux
-- Armel Kali Linux
-- Armhf Kali Linux
-- Alpine Linux
-
-BSD buildbots:
-- OpenBSD
-- FreeBSD
-- NetBSD
-- DragonflyBSD
-
 == Documentation ==
 
 Some more information is present in the README file.

--- a/README.md
+++ b/README.md
@@ -500,24 +500,6 @@ Aircrack-ng is available in most distributions repositories. However, it is not 
 - PVS-Studio static analysis (GitHub actions): https://github.com/aircrack-ng/aircrack-ng/actions/workflows/pvs-studio.yml
 - Coverity Scan static analysis: https://scan.coverity.com/projects/aircrack-ng
 
-## Buildbots
-
-URL: https://buildbot.aircrack-ng.org/
-
-Linux buildbots:
-- CentOS
-- AArch64
-- Kali Linux
-- Armel Kali Linux
-- Armhf Kali Linux
-- Alpine Linux
-
-BSD buildbots:
-- OpenBSD
-- FreeBSD
-- NetBSD
-- DragonflyBSD
-
 # Documentation
 
 Some more information is present in the [README](README) file.


### PR DESCRIPTION
Removed the buildbot chapters from the documentations as they have been [decommissioned](https://github.com/aircrack-ng/aircrack-ng/commit/7f833e548cf077e4bc1ee152ae4b143dcdb9748a).