### PR TITLE
autogen.sh: fix shellcheck findings

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -44,7 +44,6 @@ set -euf
 test -n "${srcdir:-}" || srcdir="$(dirname "$0")"
 test -n "${srcdir:-}" || srcdir=.
 
-olddir="$(pwd)"
 cd "$srcdir"
 
 missing_tool()
@@ -100,7 +99,7 @@ if [ -z "${AUTOMAKE:-}" ]; then
 fi
 
 "$LIBTOOLIZE" --force --copy --automake
-"$ACLOCAL" -I build/m4/stubs -I build/m4 ${ACLOCAL_FLAGS:-}
+"$ACLOCAL" -I build/m4/stubs -I build/m4 "${ACLOCAL_FLAGS:-}"
 "$AUTOCONF"
 "$AUTOHEADER"
 "$AUTOMAKE" \
@@ -114,7 +113,7 @@ EOF
 } > reautogen.sh
 chmod +x reautogen.sh
 
-if [ ! -z "${NOCONFIGURE:-}" ]; then
+if [ -n "${NOCONFIGURE:-}" ]; then
     echo "Done. ./configure skipped."
     exit $?
 fi


### PR DESCRIPTION
Fixed `shellcheck` findings in `autogen.sh`.

`shellcheck` version:
```
$ shellcheck -V
ShellCheck - shell script analysis tool
version: 0.8.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net
```

Verifying `olddir` variable is unused:
```
$ grep -rni . -e 'olddir'
./autogen.sh:47:olddir="$(pwd)"
```