### PR TITLE
airodump-ng: fix displaying -M and -W columns (follow-up)

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -3777,7 +3777,8 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 				{
 					memset(strbuf + columns_ap + lopt.maxsize_wps_seen + 1,
 						   ' ',
-						   sizeof(strbuf) - columns_ap - lopt.maxsize_wps_seen);
+						   sizeof(strbuf) - columns_ap - lopt.maxsize_wps_seen
+							   - 1);
 					snprintf(strbuf + columns_ap + lopt.maxsize_wps_seen
 								 + lopt.maxsize_essid_seen
 								 - strlen("ESSID"),


### PR DESCRIPTION
After reviewing #2488 once again I noticed a bug. I set the number of bytes in a `memset()` call wrong and this results in a buffer overflow. It has no visible symptoms though probably because it is only 1 byte but now this is fixed.