### PR TITLE
airodump-ng: fix displaying of station 'Rate' and 'Lost' columns

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -4210,7 +4210,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 	{
 		strlcpy(strbuf,
 				" BSSID              STATION "
-				"           PWR   Rate    Lost    Frames  Notes  Probes",
+				"           PWR    Rate    Lost   Frames  Notes  Probes",
 				sizeof(strbuf));
 		strbuf[ws_col - 1] = '\0';
 		console_puts(strbuf);


### PR DESCRIPTION
Fixed some indentation issues in the displaying of stations in `airodump-ng`.

Before:

```
$ sudo airodump-ng wlp0s20f0u1
 BSSID              STATION            PWR   Rate    Lost    Frames  Notes  Probes

 XX:XX:XX:XX:XX:XX  XX:XX:XX:XX:XX:XX  -55    0 - 6      0        1
```

As you can see `Rate` and `Lost` column titles are shifted by one space.

After:

```
$ sudo ./airodump-ng wlp0s20f0u1
 BSSID              STATION            PWR    Rate    Lost   Frames  Notes  Probes

 (not associated)   XX:XX:XX:XX:XX:XX  -87    0 - 1     18        6         XXXXXXXXXX
```