### PR TITLE
improve clang_format_all.sh

### DIFF
--- a/build/clang_format_all.sh
+++ b/build/clang_format_all.sh
@@ -34,10 +34,8 @@ if test ! -e configure.ac; then
     exit 1;
 fi;
 
-if ! valid_clang_format; then
-	# if not valid yet, first try the command line parameter
-	CLANG_FORMAT=$1
-fi;
+# First try the command line parameter
+CLANG_FORMAT=$1
 
 if ! valid_clang_format; then
 	# Next try the full version

--- a/build/clang_format_all.sh
+++ b/build/clang_format_all.sh
@@ -21,7 +21,6 @@ CLANG_FORMAT_VERSION=$CLANG_MAJOR.$CLANG_MINOR
 valid_clang_format() {
 	if which "$CLANG_FORMAT" > /dev/null 2>&1; then
 		if $CLANG_FORMAT --version | grep -q $CLANG_FORMAT_VERSION; then
-			echo "Located $CLANG_FORMAT";
 			return 0;
 		fi
 	fi
@@ -61,6 +60,8 @@ if ! valid_clang_format; then
 	echo "'clang-format-$CLANG_FORMAT_VERSION' so that it doesn't interfere with any other"
 	echo "versions you might have installed, and this script will find it there"
 	exit 1;
+else
+	echo "Located $CLANG_FORMAT";
 fi;
 
 # Format all source code


### PR DESCRIPTION
Improved `clang_format_all.sh` a bit. Removed one unnecessary if statement which always failed as variable `CLANG_FORMAT` is not set before. There are no other scripts sourced so we can not even import it from there.

If `clang-format` is passed as a cmd line arg then the following message is being printed many times:
```
$ ./build/clang_format_all.sh clang-format                                                     
Located clang-format
Located clang-format
Located clang-format
Located clang-format
```

This is also fixed:
```
$ ./build/clang_format_all.sh clang-format
Located clang-format
```