### PR TITLE
airdecap-ng: make test-0005.sh more verbose

### DIFF
--- a/test/test-airdecap-ng-0005.sh
+++ b/test/test-airdecap-ng-0005.sh
@@ -8,16 +8,34 @@ if type "md5" > /dev/null 2>/dev/null ; then
 	MD5_BIN="md5 -q"
 fi
 
-"${abs_builddir}/../airdecap-ng${EXEEXT}" \
+airdecap_output=$("${abs_builddir}/../airdecap-ng${EXEEXT}" \
 	"${abs_srcdir}/capture_wds-01.cap" \
 	-e test1 \
 	-p 12345678 \
 	-b 00:11:22:00:00:00 \
-	-o ${TMP_DEC} | \
-		cut -b 40- | \
-		 tr -d ' ' | \
-		${MD5_BIN} | \
-		cut -b 1-32 > ${TMP_MD5}
+	-o ${TMP_DEC})
+
+# shellcheck disable=SC2181
+if [ $? != 0 ]; then
+  echo "$airdecap_output"
+  CAP_MD5=$(md5sum "${abs_srcdir}"/capture_wds-01.cap | cut -b 1-32)
+  # shellcheck disable=SC2012
+  CAP_SIZE=$(ls -l "${abs_srcdir}"/capture_wds-01.cap | cut -d " " -f5)
+  if [ "${CAP_MD5}" != '9f5d20d70a5d27b8de1b094cec77b8dd' ]; then
+    echo "Corrupt .cap file"
+    echo "Expected .cap MD5 hash: 9f5d20d70a5d27b8de1b094cec77b8dd"
+    echo "Actual .cap MD5 hash: ${CAP_MD5}"
+    echo "Expected .cap size: 21113 bytes"
+    echo "Actual .cap size: ${CAP_SIZE} bytes"
+  fi
+  exit 1
+else
+  echo "$airdecap_output" | \
+  cut -b 40- | \
+   tr -d ' ' | \
+  ${MD5_BIN} | \
+  cut -b 1-32 > "${TMP_MD5}"
+fi
 
 if [ "$(cat ${TMP_MD5})" != '45a93bc091a3929a7d63f86ddbb81401' ]; then
 	#rm ${TMP_MD5} ${TMP_DEC}


### PR DESCRIPTION
Made `test-airdecap-ng-0005.sh` more verbose, so we can debug #2506 the next time we encounter the issue. My first guess is that `capture_wds-01.cap` becomes corrupt somehow.

Determining the md5 and size of `capture_wds-01.cap`:
```
$ md5sum test/capture_wds-01.cap
9f5d20d70a5d27b8de1b094cec77b8dd  test/capture_wds-01.cap
$ ls -l test/capture_wds-01.cap 
-rw-r--r--. 1 gemesa gemesa 21113 Mar 12 19:02 test/capture_wds-01.cap
```

Test measurements:

Normal circumstances:
```
$ ./test/test-airdecap-ng-0005.sh    
$ echo $?
0
```

Corrupting `capture_wds-01.cap` manually:
```
$ ./test/test-airdecap-ng-0005.sh
"/home/gemesa/git-repos/aircrack-ng/test/capture_wds-01.cap" isn't a pcap file (expected TCPDUMP_MAGIC).
Corrupt .cap file
Expected .cap MD5 hash: 9f5d20d70a5d27b8de1b094cec77b8dd
Actual .cap MD5 hash: a37e03b6d55e81a06dc6c1b4c2aae908
Expected .cap size: 21113 bytes
Actual .cap size: 34092 bytes
$ echo $?
1
```