### PR TITLE
clang_format_all.sh: add support for clang-format-12/13/14/15

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -134,12 +134,12 @@ jobs:
           git diff
 
           set -e && git diff --quiet || (
-            echo "***************************************************";
-            echo "*** The code is not clean against clang-format  ***";
-            echo "*** Please run clang-format-12.0 and fix the    ***";
-            echo "*** differences then rebase/squash them into    ***";
-            echo "*** the relevant commits. Do not add a commit   ***";
-            echo "*** for just formatting fixes. Thanks!          ***";
-            echo "***************************************************";
+            echo "****************************************************";
+            echo "*** The code is not clean against clang-format   ***";
+            echo "*** Please run clang-format-12/13/14/15 and fix  ***";
+            echo "*** the differences then rebase/squash them into ***";
+            echo "*** the relevant commits. Do not add a commit    ***";
+            echo "*** for just formatting fixes. Thanks!           ***";
+            echo "****************************************************";
             exit 1;
           )

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Check source code formatting
         run: |
           echo "::group::Process all source files with clang-format"
-          # check formatting matches clang-format-12.0. Since newer versions can
+          # check formatting matches clang-format-12. Since newer versions can
           # have changes in formatting even without any rule changes, we have
           # to fix on a single version.
           . ./build/clang_format_all.sh

--- a/build/clang_format_all.sh
+++ b/build/clang_format_all.sh
@@ -1,26 +1,29 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Adapted from:
 #   https://github.com/baldurk/renderdoc/raw/v1.x/util/clang_format_all.sh
 #
 
-CLANG_MAJOR=12
-CLANG_MINOR=0
-
-CLANG_FORMAT_VERSION=$CLANG_MAJOR.$CLANG_MINOR
+# shellcheck disable=SC2039
+CLANG_VERSION=(12 13 14 15)
 
 # Locate the clang-format executable. We try:
 #   - the existing value of $CLANG_FORMAT
 #   - the first command line argument to the script
 #   - in order:
-#      clang-format-Maj.Min
 #      clang-format-Maj
 #      clang-format
 
 # define a function to check the current $CLANG_FORMAT
 valid_clang_format() {
 	if which "$CLANG_FORMAT" > /dev/null 2>&1; then
-		if $CLANG_FORMAT --version | grep -q $CLANG_FORMAT_VERSION; then
+	  # we need to make the grep pattern strict because if clang-format was built from source
+	  # then the version number contains a hash and grep could match numbers from it
+	  # for example:
+	  # $ clang-format-12 --version
+	  # clang-format version 12.0.1 (https://github.com/llvm/llvm-project.git fed41342a82f5a3a9201819a82bf7a48313e296b)
+		if $CLANG_FORMAT --version | grep -q "version $1"; then
+      echo "Located $CLANG_FORMAT";
 			return 0;
 		fi
 	fi
@@ -28,48 +31,52 @@ valid_clang_format() {
 	return 1;
 }
 
+# Format all source code
+format_code() {
+  find src -iname '*.h' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
+      xargs -0 -n1 $CLANG_FORMAT -i -style=file
+  find src -iname '*.cpp' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
+      xargs -0 -n1 $CLANG_FORMAT -i -style=file
+  find src -iname '*.c' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
+      xargs -0 -n1 $CLANG_FORMAT -i -style=file
+  $CLANG_FORMAT -i -style=file include/aircrack-ng/third-party/eapol.h
+  $CLANG_FORMAT -i -style=file include/aircrack-ng/third-party/hashcat.h
+}
+
 if test ! -e configure.ac; then
     echo "Must be at the root of the entire project."
     exit 1;
 fi;
 
-# First try the command line parameter
-CLANG_FORMAT=$1
-
-if ! valid_clang_format; then
-	# Next try the full version
-	CLANG_FORMAT=clang-format-$CLANG_MAJOR.$CLANG_MINOR
-fi;
-
-if ! valid_clang_format; then
+for clang_version in "${CLANG_VERSION[@]}"; do
+  # First try the command line parameter
+  CLANG_FORMAT=$1
+  if valid_clang_format "$clang_version"; then
+    format_code
+    exit 0
+  fi
+done
+for clang_version in "${CLANG_VERSION[@]}"; do
 	# Then -maj just in case
-	CLANG_FORMAT=clang-format-$CLANG_MAJOR
-fi;
+	CLANG_FORMAT=clang-format-$clang_version
+  if valid_clang_format "$clang_version"; then
+    format_code
+    exit 0
+  fi
+done
+for clang_version in "${CLANG_VERSION[@]}"; do
+  # Then finally with no version suffix
+  CLANG_FORMAT=clang-format
+  if valid_clang_format "$clang_version"; then
+    format_code
+    exit 0
+  fi
+done
 
-if ! valid_clang_format; then
-	# Then finally with no version suffix
-	CLANG_FORMAT=clang-format
-fi;
-
-# Check if we have a valid $CLANG_FORMAT
-if ! valid_clang_format; then
-	# If we didn't find one, bail out
-	echo "Couldn't find correct clang-format version, was looking for $CLANG_FORMAT_VERSION"
-	echo "Aircrack-ng requires a very specific clang-format version to ensure there isn't"
-	echo "any variance between versions that can happen. You can install it as"
-	echo "'clang-format-$CLANG_FORMAT_VERSION' so that it doesn't interfere with any other"
-	echo "versions you might have installed, and this script will find it there"
-	exit 1;
-else
-	echo "Located $CLANG_FORMAT";
-fi;
-
-# Format all source code
-find src -iname '*.h' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
-    xargs -0 -n1 $CLANG_FORMAT -i -style=file
-find src -iname '*.cpp' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
-    xargs -0 -n1 $CLANG_FORMAT -i -style=file
-find src -iname '*.c' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
-    xargs -0 -n1 $CLANG_FORMAT -i -style=file
-$CLANG_FORMAT -i -style=file include/aircrack-ng/third-party/eapol.h
-$CLANG_FORMAT -i -style=file include/aircrack-ng/third-party/hashcat.h
+# We didn't find a valid $CLANG_FORMAT, bail out
+echo -n "Couldn't find a correct clang-format version, was looking for "; IFS='/';echo "${CLANG_VERSION[*]}";IFS=$' \t\n'
+echo "Aircrack-ng requires a very specific clang-format version to ensure there isn't"
+echo "any variance between versions that can happen. You can install it as"
+echo -n "'clang-format-"; IFS='/';echo -n "${CLANG_VERSION[*]}";IFS=$' \t\n'; echo "' so that it doesn't interfere with any other"
+echo "versions you might have installed, and this script will find it there"
+exit 1;

--- a/build/clang_format_all.sh
+++ b/build/clang_format_all.sh
@@ -16,13 +16,13 @@ CLANG_VERSION=(12 13 14 15)
 # define a function to check the current $CLANG_FORMAT
 valid_clang_format() {
 	if which "$CLANG_FORMAT" > /dev/null 2>&1; then
-	  # we need to make the grep pattern strict because if clang-format was built from source
-	  # then the version number contains a hash and grep could match numbers from it
-	  # for example:
-	  # $ clang-format-12 --version
-	  # clang-format version 12.0.1 (https://github.com/llvm/llvm-project.git fed41342a82f5a3a9201819a82bf7a48313e296b)
+		# we need to make the grep pattern strict because if clang-format was built from source
+		# then the version number contains a hash and grep could match numbers from it
+		# for example:
+		# $ clang-format-12 --version
+		# clang-format version 12.0.1 (https://github.com/llvm/llvm-project.git fed41342a82f5a3a9201819a82bf7a48313e296b)
 		if $CLANG_FORMAT --version | grep -q "version $1"; then
-      echo "Located $CLANG_FORMAT";
+			echo "Located $CLANG_FORMAT";
 			return 0;
 		fi
 	fi
@@ -32,44 +32,44 @@ valid_clang_format() {
 
 # Format all source code
 format_code() {
-  find src -iname '*.h' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
-      xargs -0 -n1 $CLANG_FORMAT -i -style=file
-  find src -iname '*.cpp' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
-      xargs -0 -n1 $CLANG_FORMAT -i -style=file
-  find src -iname '*.c' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
-      xargs -0 -n1 $CLANG_FORMAT -i -style=file
-  $CLANG_FORMAT -i -style=file include/aircrack-ng/third-party/eapol.h
-  $CLANG_FORMAT -i -style=file include/aircrack-ng/third-party/hashcat.h
+	find src -iname '*.h' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
+			xargs -0 -n1 $CLANG_FORMAT -i -style=file
+	find src -iname '*.cpp' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
+			xargs -0 -n1 $CLANG_FORMAT -i -style=file
+	find src -iname '*.c' -a \( ! -path "include/aircrack-ng/third-party/*" -a ! -path "lib/radiotap/*" \) -print0 | \
+			xargs -0 -n1 $CLANG_FORMAT -i -style=file
+	$CLANG_FORMAT -i -style=file include/aircrack-ng/third-party/eapol.h
+	$CLANG_FORMAT -i -style=file include/aircrack-ng/third-party/hashcat.h
 }
 
 if test ! -e configure.ac; then
-    echo "Must be at the root of the entire project."
-    exit 1;
+	echo "Must be at the root of the entire project."
+	exit 1;
 fi;
 
 for clang_version in "${CLANG_VERSION[@]}"; do
-  # First try the command line parameter
-  CLANG_FORMAT=$1
-  if valid_clang_format "$clang_version"; then
-    format_code
-    exit 0
-  fi
+	# First try the command line parameter
+	CLANG_FORMAT=$1
+	if valid_clang_format "$clang_version"; then
+		format_code
+		exit 0
+	fi
 done
 for clang_version in "${CLANG_VERSION[@]}"; do
 	# Then -maj just in case
 	CLANG_FORMAT=clang-format-$clang_version
-  if valid_clang_format "$clang_version"; then
-    format_code
-    exit 0
-  fi
+	if valid_clang_format "$clang_version"; then
+		format_code
+		exit 0
+	fi
 done
 for clang_version in "${CLANG_VERSION[@]}"; do
-  # Then finally with no version suffix
-  CLANG_FORMAT=clang-format
-  if valid_clang_format "$clang_version"; then
-    format_code
-    exit 0
-  fi
+	# Then finally with no version suffix
+	CLANG_FORMAT=clang-format
+	if valid_clang_format "$clang_version"; then
+		format_code
+		exit 0
+	fi
 done
 
 # We didn't find a valid $CLANG_FORMAT, bail out

--- a/build/clang_format_all.sh
+++ b/build/clang_format_all.sh
@@ -4,7 +4,6 @@
 #   https://github.com/baldurk/renderdoc/raw/v1.x/util/clang_format_all.sh
 #
 
-# shellcheck disable=SC2039
 CLANG_VERSION=(12 13 14 15)
 
 # Locate the clang-format executable. We try:


### PR DESCRIPTION
Updated `clang_format_all.sh` to accept `clang-format-12/13/14/15` according to https://github.com/aircrack-ng/aircrack-ng/pull/2511#issuecomment-1465327812. I removed the minor version number as [they are usually 0](https://releases.llvm.org/) in the new release model.
I tested the different versions to make sure they output the same code:

```
gemesa@ubuntu-pc:~/git-repos/aircrack-ng-gemesa$ ./build/clang_format_all.sh clang-format-12
Located clang-format-12
gemesa@ubuntu-pc:~/git-repos/aircrack-ng-gemesa$ git status
On branch clang-format-x
Your branch is up to date with 'origin/clang-format-x'.

nothing to commit, working tree clean
gemesa@ubuntu-pc:~/git-repos/aircrack-ng-gemesa$ ./build/clang_format_all.sh clang-format-13
Located clang-format-13
gemesa@ubuntu-pc:~/git-repos/aircrack-ng-gemesa$ git status
On branch clang-format-x
Your branch is up to date with 'origin/clang-format-x'.

nothing to commit, working tree clean
gemesa@ubuntu-pc:~/git-repos/aircrack-ng-gemesa$ ./build/clang_format_all.sh clang-format-14
Located clang-format-14
gemesa@ubuntu-pc:~/git-repos/aircrack-ng-gemesa$ git status
On branch clang-format-x
Your branch is up to date with 'origin/clang-format-x'.

nothing to commit, working tree clean
gemesa@ubuntu-pc:~/git-repos/aircrack-ng-gemesa$ ./build/clang_format_all.sh clang-format-15
Located clang-format-15
gemesa@ubuntu-pc:~/git-repos/aircrack-ng-gemesa$ git status
On branch clang-format-x
Your branch is up to date with 'origin/clang-format-x'.

nothing to commit, working tree clean
```

Testing to see if it also works without a cmd line arg and with default `clang-format`:
```
gemesa@ubuntu-pc:~/git-repos/aircrack-ng-gemesa$ ./build/clang_format_all.sh
Located clang-format-12
gemesa@ubuntu-pc:~/git-repos/aircrack-ng-gemesa$ ./build/clang_format_all.sh clang-format
Located clang-format
gemesa@ubuntu-pc:~/git-repos/aircrack-ng-gemesa$
```

Testing to see what happens if no proper version of `clang-format` is installed:

Modify `clang_format_all.sh` manually:
```
...
CLANG_VERSION=(9 10 11)
...
```

```
$ ./build/clang_format_all.sh                
Couldn't find a correct clang-format version, was looking for 9/10/11
Aircrack-ng requires a very specific clang-format version to ensure there isn't
any variance between versions that can happen. You can install it as
'clang-format-9/10/11' so that it doesn't interfere with any other
versions you might have installed, and this script will find it there
```