### PR TITLE
.pre-commit-config.yaml: remove enforcing of clang-format 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: v1.3.5
     hooks:
       - id: clang-format
-        args: ["--version=3.8", "--style=file", "-i"]
+        args: ["--style=file", "-i"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.7.2.1


### PR DESCRIPTION
Follow-up of #2511 and #2512 