### PR TITLE
workflows: fix build with clang* in linux CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -176,15 +176,9 @@ jobs:
         run: |
           CPUS=$(nproc)
           case "${{ matrix.compiler.cc }}" in
-            clang-12)
-              CC=clang-11
-              CXX=clang++-11
-              export CFLAGS="-Werror -Wno-zero-length-array -Wno-deprecated-declarations"
-              export CXXFLAGS="-Werror -Wno-zero-length-array -Wno-deprecated-declarations"
-              ;;
-            clang-11)
-              CC=clang-11
-              CXX=clang++-11
+            clang*)
+              CC=${{ matrix.compiler.cc }}
+              CXX=${{ matrix.compiler.cxx }}
               export CFLAGS="-Werror -Wno-zero-length-array -Wno-deprecated-declarations"
               export CXXFLAGS="-Werror -Wno-zero-length-array -Wno-deprecated-declarations"
               ;;


### PR DESCRIPTION
Fixed broken builds: 

[Ubuntu 22.04 clang-12 using Gcrypt](https://github.com/aircrack-ng/aircrack-ng/actions/runs/4420816213/jobs/7750961358#logs):

```
  configure:5175: checking for C compiler version
  configure:5184: ccache clang-11 --version >&5
  ccache: error: Could not find compiler "clang-11" in PATH
  configure:5195: $? = 1
```

[Ubuntu 22.04 clang-12 using OpenSSL](https://github.com/aircrack-ng/aircrack-ng/actions/runs/4420816213/jobs/7750961443#logs):
```
  configure:5175: checking for C compiler version
  configure:5184: ccache clang-11 --version >&5
  ccache: error: Could not find compiler "clang-11" in PATH
  configure:5195: $? = 1
```

Fixed `clang-13` and `clang-14` builds where the options meant for `gcc` are used currently (instead of `-Werror -Wno-zero-length-array -Wno-deprecated-declarations`):

[Ubuntu 22.04 clang-14 using OpenSSL](https://github.com/aircrack-ng/aircrack-ng/actions/runs/4420816213/jobs/7750961825#logs):
```
      C Compiler:                  ccache clang-14
      C++ Compiler:                ccache clang++-14 -std=gnu++17
      Python:                      python
  
      CFLAGS:                      -Werror -Wno-unused-result -Wno-deprecated-declarations
      CXXFLAGS:                    -Werror -Wno-unused-result -Wno-deprecated-declarations
```

[Ubuntu 22.04 clang-13 using OpenSSL](https://github.com/aircrack-ng/aircrack-ng/actions/runs/4420816213/jobs/7750961648#logs):
```
      C Compiler:                  ccache clang-13
      C++ Compiler:                ccache clang++-13 -std=gnu++17
      Python:                      python
  
      CFLAGS:                      -Werror -Wno-unused-result -Wno-deprecated-declarations
      CXXFLAGS:                    -Werror -Wno-unused-result -Wno-deprecated-declarations
```