### PR TITLE
airdecap-ng: make test-0005.sh more verbose

### DIFF
--- a/test/test-airdecap-ng-0005.sh
+++ b/test/test-airdecap-ng-0005.sh
@@ -39,7 +39,10 @@ fi
 
 if [ "$(cat ${TMP_MD5})" != '45a93bc091a3929a7d63f86ddbb81401' ]; then
 	#rm ${TMP_MD5} ${TMP_DEC}
-	echo "Unexpected airdecap-ng output"
+	echo "Unexpected airdecap-ng output:"
+	echo "$airdecap_output"
+	echo "Expected MD5 hash: 45a93bc091a3929a7d63f86ddbb81401"
+	echo "Actual MD5 hash: ${TMP_MD5}"
 	echo "Decrypted file: ${TMP_DEC}"
 	exit 1
 fi


### PR DESCRIPTION
Follow-up of #2510

Made `test-airdecap-ng-0005.sh` more verbose, so we can debug #2506 further the next time we encounter the issue. 

In [jobs/7757968179](https://github.com/aircrack-ng/aircrack-ng/actions/runs/4424304425/jobs/7757968179) `test/test-airdecap-ng-0005.sh` failed again:
```
  Unexpected airdecap-ng output
  Decrypted file: /tmp/tmp.wcUz6ZXJUi
  FAIL test/test-airdecap-ng-0005.sh (exit status: 1)
```

It looks like `airdecap-ng` returned 0 but still the calculated hash does not match.