### PR TITLE
test-airbase-ng-000*.sh: remove double quotes for args to enable word splitting

### DIFF
--- a/test/test-airbase-ng-0001.sh
+++ b/test/test-airbase-ng-0001.sh
@@ -114,7 +114,7 @@ fi
 
 # Crack the capture
 timeout 60 "${abs_builddir}/../aircrack-ng${EXEEXT}" \
-    "${AIRCRACK_NG_ARGS}" \
+    ${AIRCRACK_NG_ARGS} \
     -w "${abs_srcdir}/password.lst" \
     -a 2 \
     -e "${SSID}" \

--- a/test/test-airbase-ng-0002.sh
+++ b/test/test-airbase-ng-0002.sh
@@ -117,7 +117,7 @@ fi
 
 # Crack the capture
 timeout 60 "${abs_builddir}/../aircrack-ng${EXEEXT}" \
-    "${AIRCRACK_NG_ARGS}" \
+    ${AIRCRACK_NG_ARGS} \
     -w "${abs_srcdir}/password.lst" \
     -a 2 \
     -e "${SSID}" \

--- a/test/test-airbase-ng-0003.sh
+++ b/test/test-airbase-ng-0003.sh
@@ -132,7 +132,7 @@ fi
 
 # Crack the capture
 timeout 60 "${abs_builddir}/../aircrack-ng${EXEEXT}" \
-    "${AIRCRACK_NG_ARGS}" \
+    ${AIRCRACK_NG_ARGS} \
     -w "${abs_srcdir}/password.lst" \
     -a 2 \
     -e "${SSID}" \


### PR DESCRIPTION
After reviewing #2519 #2520 #2521 once again I noticed there was one place where I should not have added double quotes because we want the arguments expanded from `AIRCRACK_NG_ARGS` passed separately to `aircrack-ng`.