### PR TITLE
autogen.sh: remove double quotes for args to enable word splitting

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -99,7 +99,7 @@ if [ -z "${AUTOMAKE:-}" ]; then
 fi
 
 "$LIBTOOLIZE" --force --copy --automake
-"$ACLOCAL" -I build/m4/stubs -I build/m4 "${ACLOCAL_FLAGS:-}"
+"$ACLOCAL" -I build/m4/stubs -I build/m4 ${ACLOCAL_FLAGS:-}
 "$AUTOCONF"
 "$AUTOHEADER"
 "$AUTOMAKE" \


### PR DESCRIPTION
After reviewing #2494  once again I noticed there was one place where I should not have added double quotes because we want the arguments expanded from `ACLOCAL_FLAGS` passed separately to `aclocal`.