### PR TITLE
airdecap-ng: make test-0005.sh more verbose

### DIFF
--- a/test/test-airdecap-ng-0005.sh
+++ b/test/test-airdecap-ng-0005.sh
@@ -42,7 +42,7 @@ if [ "$(cat ${TMP_MD5})" != '45a93bc091a3929a7d63f86ddbb81401' ]; then
 	echo "Unexpected airdecap-ng output:"
 	echo "$airdecap_output"
 	echo "Expected MD5 hash: 45a93bc091a3929a7d63f86ddbb81401"
-	echo "Actual MD5 hash: ${TMP_MD5}"
+	echo -n "Actual MD5 hash: "; cat ${TMP_MD5}
 	echo "Decrypted file: ${TMP_DEC}"
 	exit 1
 fi


### PR DESCRIPTION
Follow-up of #2523 where I print the name of the tmp file instead of its content:
```
echo "Actual MD5 hash: ${TMP_MD5}"
```

Should be:
```
echo -n "Actual MD5 hash: "; cat ${TMP_MD5}
```

We encountered though [this weird test failure](https://github.com/aircrack-ng/aircrack-ng/actions/runs/4429572802/jobs/7770205306) once again. I checked manually the expected output of `airdecap-ng`:

```
$ ./test/test-airdecap-ng-0005.sh
...
Total number of stations seen            1
Total number of packets read           139
Total number of WEP data packets         0
Total number of WPA data packets        46
Number of plaintext data packets         0
Number of decrypted WEP  packets         0
Number of corrupted WEP  packets         0
Number of decrypted WPA  packets        46
Number of bad TKIP (WPA) packets         0
Number of bad CCMP (WPA) packets         0
...
```

and this is what we get in the failed CI run:

```
Read 24 packets...
Total number of stations seen            1
Total number of packets read           139
Total number of WEP data packets         0
Total number of WPA data packets        46
Number of plaintext data packets         0
Number of decrypted WEP  packets         0
Number of corrupted WEP  packets         0
Number of decrypted WPA  packets        46
Number of bad TKIP (WPA) packets         0
Number of bad CCMP (WPA) packets         0
```

Notice that there is that extra line `Read 24 packets...`. Maybe this is what causes the MD5 mismatch. We can make sure next time we encounter this because then the calculated MD5 will be printed also in the CI.