### PR TITLE
airdecap-ng: fix test-0005.sh

### DIFF
--- a/test/test-airdecap-ng-0005.sh
+++ b/test/test-airdecap-ng-0005.sh
@@ -18,16 +18,6 @@ airdecap_output=$("${abs_builddir}/../airdecap-ng${EXEEXT}" \
 # shellcheck disable=SC2181
 if [ $? != 0 ]; then
   echo "$airdecap_output"
-  CAP_MD5=$(md5sum "${abs_srcdir}"/capture_wds-01.cap | cut -b 1-32)
-  # shellcheck disable=SC2012
-  CAP_SIZE=$(ls -l "${abs_srcdir}"/capture_wds-01.cap | cut -d " " -f5)
-  if [ "${CAP_MD5}" != '9f5d20d70a5d27b8de1b094cec77b8dd' ]; then
-    echo "Corrupt .cap file"
-    echo "Expected .cap MD5 hash: 9f5d20d70a5d27b8de1b094cec77b8dd"
-    echo "Actual .cap MD5 hash: ${CAP_MD5}"
-    echo "Expected .cap size: 21113 bytes"
-    echo "Actual .cap size: ${CAP_SIZE} bytes"
-  fi
   exit 1
 else
   echo "$airdecap_output" | \
@@ -41,8 +31,6 @@ if [ "$(cat ${TMP_MD5})" != '45a93bc091a3929a7d63f86ddbb81401' ]; then
 	#rm ${TMP_MD5} ${TMP_DEC}
 	echo "Unexpected airdecap-ng output:"
 	echo "$airdecap_output"
-	echo "Expected MD5 hash: 45a93bc091a3929a7d63f86ddbb81401"
-	echo "Actual MD5 hash: ${TMP_MD5}"
 	echo "Decrypted file: ${TMP_DEC}"
 	exit 1
 fi

--- a/test/test-airdecap-ng-0005.sh
+++ b/test/test-airdecap-ng-0005.sh
@@ -21,6 +21,7 @@ if [ $? != 0 ]; then
   exit 1
 else
   echo "$airdecap_output" | \
+  grep -E '(Total|Number) ' | \
   cut -b 40- | \
    tr -d ' ' | \
   ${MD5_BIN} | \


### PR DESCRIPTION
Fixes #2506 

Follow-up of #2526 where we discovered why `test-airdecap-ng-0005.sh` fails in CIs sometimes. This PR removes the debug code added to identify the issue and also stabilizes the unit test.

I added the regex pattern `'(Total|Number) '` instead of the proposed `'^(Total|Number) '` because the first line of variable `airdecap_output` starts with `ESC[2K` where `ESC[2K` is an ANSI escape code sequence used in shell terminals to clear the entire current line AFAIK.

The pattern was not matching the first line during testing so I piped `airdecap_output` to a file then I saw why:
```
[2KTotal number of stations seen            1
Total number of packets read           139
Total number of WEP data packets         0
Total number of WPA data packets        46
Number of plaintext data packets         0
Number of decrypted WEP  packets         0
Number of corrupted WEP  packets         0
Number of decrypted WPA  packets        46
Number of bad TKIP (WPA) packets         0
Number of bad CCMP (WPA) packets         0
```