### PR TITLE
readme, installing: update obsolete --without-opt description

### DIFF
--- a/INSTALLING
+++ b/INSTALLING
@@ -235,7 +235,7 @@ to your choosing:
 
 * disable-libnl:  Set up the project to be compiled without libnl (1 or 3). Linux option only.
 
-* without-opt:  Do not enable stack protector (on GCC 4.9 and above).
+* without-opt:  Do not enable -O3 optimizations.
 
 * enable-shared:   Make a OSdep a shared library.
 

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ to your choosing:
 
 * **disable-libnl**:  Set up the project to be compiled without libnl (1 or 3). Linux option only.
 
-* **without-opt**:  Do not enable stack protector (on GCC 4.9 and above).
+* **without-opt**:  Do not enable -O3 optimizations.
 
 * **enable-shared**:   Make OSdep a shared library.
 


### PR DESCRIPTION
`--without-opt` related documentation has not been updated lately. Now this option enables/disables `-O3`:

```
$ ./configure --without-opt --with-experimental --enable-maintainer-mode
...
    Optimized CFLAGS:            -DEXPENSIVE_TESTS  -Wall -std=gnu99 -fcommon -Wstrict-overflow=2 -fvisibility=hidden -pedantic -Wextra -Werror -Wstrict-prototypes -Wpointer-arith -Wno-gnu-zero-variadic-macro-arguments
    Optimized CXXFLAGS:           -Wall -fvisibility=hidden -pedantic -Wextra -Werror -Wpointer-arith -Wno-gnu-zero-variadic-macro-arguments
...
```

```
$ ./configure --with-experimental --enable-maintainer-mode
...
    Optimized CFLAGS:            -DEXPENSIVE_TESTS  -Wall -O3 -std=gnu99 -fcommon -Wstrict-overflow=2 -fvisibility=hidden -pedantic -Wextra -Werror -Wstrict-prototypes -Wpointer-arith -Wno-gnu-zero-variadic-macro-arguments
    Optimized CXXFLAGS:           -Wall -O3 -fvisibility=hidden -pedantic -Wextra -Werror -Wpointer-arith -Wno-gnu-zero-variadic-macro-arguments
...
```

So I have updated the docs accordingly.

The older related commits:
```
$ git log --grep without-opt
commit ac14580da4648577fd75e278d53b6c5996bbeb65
Author: Mister-X- <3520734+Mister-X-@users.noreply.github.com>
Date:   Thu Feb 16 09:28:59 2023 -0600

    Dockerfile: remove --without-opt (Closes: #2446)

commit 7757cf70f3b54e935e14a208e69fabfce1c96c93
Author: Thomas d'Otreppe <3520734+Mister-X-@users.noreply.github.com>
Date:   Tue Apr 17 18:35:38 2018 +0000

    Document --without-opt.

commit 58fe40daf3e082d9e63d689d795a3bbecf72fedb
Author: Joseph Benden <joe@benden.us>
Date:   Mon Apr 16 11:26:23 2018 -0700

    autotools: The flag --without-opt should skip stack protector flags. (#1864)
                                                                                 
```

```
$ git log --grep protector      
commit 5c0322cac08bd395bf6e343ecce6911fe3dd760a
Author: Joseph Benden <joe@benden.us>
Date:   Fri Mar 18 19:00:32 2022 -0700

    fix(build): we should not be using stack-protector
    
    We should not be making the choice of using GCC's stack-protector
    feature. The choice should be left to the distributions.
    
    Signed-off-by: Joseph Benden <joe@benden.us>

commit 58fe40daf3e082d9e63d689d795a3bbecf72fedb
Author: Joseph Benden <joe@benden.us>
Date:   Mon Apr 16 11:26:23 2018 -0700

    autotools: The flag --without-opt should skip stack protector flags. (#1864)

commit 3aab3bfe7b0968c77d7ef5bfc0b737b46dcd27b3
Author: Thomas d'Otreppe <tdotreppe@aircrack-ng.org>
Date:   Sun Jan 22 20:31:24 2017 +0000

    Added option to disable stack-protector support auto-detection in gcc.
    
    git-svn-id: http://svn.aircrack-ng.org/trunk@2889 28c6078b-6c39-48e3-add9-af49d547ecab
```
