### PR TITLE
airmon-ng.linux: in a for loop, replace `ls` with a glob

### DIFF
--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -203,8 +203,6 @@ usage() {
 handleLostPhys() {
   MISSING_INTERFACE=""
   if [ -d /sys/class/ieee80211 ]; then
-    #this should be fixed, but it's not going to be right now
-    # shellcheck disable=2045
     for i in /sys/class/ieee80211/*; do
       if [ -e "${i}" ] && [ ! -d "${i}/device/net" ]; then
         MISSING_INTERFACE="${i}"

--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -205,7 +205,7 @@ handleLostPhys() {
   if [ -d /sys/class/ieee80211 ]; then
     for i in /sys/class/ieee80211/*; do
       if [ -e "${i}" ] && [ ! -d "${i}/device/net" ]; then
-        MISSING_INTERFACE="${i}"
+        MISSING_INTERFACE="${i##*/}"
         printf "\nFound %s with no interfaces assigned, would you like to assign one to it? [y/n] " "${MISSING_INTERFACE}"
         yesorno
         retcode=$?

--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -205,8 +205,8 @@ handleLostPhys() {
   if [ -d /sys/class/ieee80211 ]; then
     #this should be fixed, but it's not going to be right now
     # shellcheck disable=2045
-    for i in $(ls /sys/class/ieee80211/); do
-      if [ ! -d "/sys/class/ieee80211/${i}/device/net" ]; then
+    for i in /sys/class/ieee80211/*; do
+      if [ -e "${i}" ] && [ ! -d "${i}/device/net" ]; then
         MISSING_INTERFACE="${i}"
         printf "\nFound %s with no interfaces assigned, would you like to assign one to it? [y/n] " "${MISSING_INTERFACE}"
         yesorno


### PR DESCRIPTION
The `[ -e` syntax covers the case of when the glob produces no matches and `sh` uses the glob pattern itself as a value for "$i".

### xtrace comparison:

#### original
```sh
set -x; 
for i in $(ls /sys/class/ieee80211/); do 
  if [ ! -d "/sys/class/ieee80211/${i}/device/net" ]; then 
    MISSING_INTERFACE="${i}"; 
    echo "$MISSING_INTERFACE" :: "$i"; 
  fi; 
done; 
set - 
```

> \++ ls --color=auto /sys/class/ieee80211/
> \+ for i in $(ls /sys/class/ieee80211/)
> \+ '[' '!' -d /sys/class/ieee80211/phy0/device/net ']'
> \+ set -
> 

#### change added
```sh
set -x; 
for i in /sys/class/ieee80211/*; do 
  if [ -e "${i}" ] && [ ! -d "${i}/device/net" ]; then 
    MISSING_INTERFACE="${i}"; 
    echo "$MISSING_INTERFACE" :: "$i"; 
  fi; 
done; 
set -
```

> \+ for i in /sys/class/ieee80211/*
> \+ '[' -e /sys/class/ieee80211/phy0 ']'
> \+ '[' '!' -d /sys/class/ieee80211/phy0/device/net ']'
> \+ set -
> 

Edit 1: formatting
Edit 2: note re `[ -e` syntax