### PR TITLE
airmon-ng.linux: add '-type l' to two `find` command; fixes bug #2556

### DIFF
--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -130,11 +130,11 @@ wireless_tools_whine() {
 
 if [ -d /sys/bus/pci ] || [ -d /sys/bus/pci_express ] || [ -d /proc/bus/pci ]; then
 	PCI_DEVICES=0
-	if [ -d /sys/bus/pci/devices ] && [ "$(find /sys/bus/pci/devices 2>/dev/null | wc -l)" != '0' ]; then
+	if [ -d /sys/bus/pci/devices ] && [ "$(find /sys/bus/pci/devices -type l 2>/dev/null | wc -l)" != '0' ]; then
 		PCI_DEVICES=1
 	elif [ -r /proc/bus/pci/devices ] && [ -n "$(cat /proc/bus/pci/devices 2>/dev/null)" ]; then
 		PCI_DEVICES=1
-	elif [ -d /sys/bus/pci_express/devices ] && [ "$(find /sys/bus/pci_express/devices 2>/dev/null | wc -l)" != '0' ]; then
+	elif [ -d /sys/bus/pci_express/devices ] && [ "$(find /sys/bus/pci_express/devices -type l 2>/dev/null | wc -l)" != '0' ]; then
 		PCI_DEVICES=1
 	fi
 


### PR DESCRIPTION
The search directory was being included in find's results.