### PR TITLE
airmon-ng.linux: fix shellcheck error SC2045 at lines 261-264, 

### DIFF
--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -258,10 +258,10 @@ findFreeInterface() {
 				IW_ERROR="$(iw phy "${PHYDEV}" interface add "wlan${i}${target_suffix}" type "${target_mode}" 2>&1)"
 				if [ -z "${IW_ERROR}" ]; then
 					if [ -d "/sys/class/ieee80211/${PHYDEV}/device/net" ]; then
-						#this should be fixed, but it's not going to be right now
-						# shellcheck disable=2045
-						for j in $(ls "/sys/class/ieee80211/${PHYDEV}/device/net/"); do
-							if [ "$(cat "/sys/class/ieee80211/${PHYDEV}/device/net/${j}/type")" = "${target_type}" ]; then
+						for j in "/sys/class/ieee80211/${PHYDEV}/device/net"/*/"type"; do
+							if [ -e "${j}" ] && [ "$(cat "${j}")" = "${target_type}" ]; then
+								j=${j%/*}
+								j=${j##*/}
 								#here is where we catch udev renaming our interface
 								k="${j#wlan}"
 								i="${k%mon}"


### PR DESCRIPTION
line 261, Remove explanatory comment.
line 262, Remove "shellcheck disable" comment.
line 263 > 261, Change an unquoted command substitution containing an `ls` command into a glob expression on the same directory path.  
line 264 > 261, Move the "type" directory name up one line. 
line 262, Add a test `[` for the existence of such a directory ( "$j" ). 
line 264 > 262, Change the argument to the `cat` command. 
lines 263 & 264, Add two parameter expansions of "$j". 
Keep the total line count and the later variables "$k" and "$i" on lines 266 and 267, respectively, the same as they were.