### PR TITLE
Manpages: Fix typos in besside-ng and airuncloak-ng

### DIFF
--- a/manpages/airdecloak-ng.1.in
+++ b/manpages/airdecloak-ng.1.in
@@ -1,7 +1,7 @@
 .TH AIRDECLOAK-NG 1 "@MAN_RELEASE_DATE@" "@MAN_RELEASE_VERSION@"
 
 .SH NAME
-airuncloak-ng - Removes wep cloaked framed from a pcap file.
+airuncloak-ng - Removes wep cloaked frames from a pcap file.
 .SH SYNOPSIS
 .B airuncloak-ng
 <options>

--- a/manpages/besside-ng.8.in
+++ b/manpages/besside-ng.8.in
@@ -28,7 +28,7 @@ Channel lock
 
 .TP
 .I -p <pps>
-Packages per second to send (flood rate).
+Packets per second to send (flood rate).
 
 .TP
 .I -W
@@ -36,7 +36,7 @@ Crack only WPA networks
 
 .TP
 .I -v
-Verbose mode. Use -vv for more verbose, -vv for even more and so on.
+Verbose mode. Use -vv for more verbose, -vvv for even more and so on.
 
 .TP
 .I -h


### PR DESCRIPTION
Fixes a couple of typos in `airuncloak-ng` and `besside-ng` linux manpages. Only docs, no changes in code.