### PR TITLE
airmon-ng.linux: fix shellcheck error SC2045 at lines 500-503

### DIFF
--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -497,10 +497,10 @@ startMac80211Iface() {
 	fi
 	#check if $1 already has a mon interface on the same phy and bail if it does
 	if [ -d "/sys/class/ieee80211/${PHYDEV}/device/net" ]; then
-		#this should be fixed, but it's not going to be right now
-		# shellcheck disable=2045
-		for i in $(ls "/sys/class/ieee80211/${PHYDEV}/device/net/"); do
-			if [ "$(cat "/sys/class/ieee80211/${PHYDEV}/device/net/${i}/type")" = "803" ]; then
+		for i in "/sys/class/ieee80211/${PHYDEV}/device/net"/*/"type"; do
+			if [ -e "${i}" ] && [ "$(cat "${i}")" = "803" ]; then
+				i=${i%/*}
+				i=${i##*/}
 				setChannelMac80211 "${i}"
 				printf "\t\t(mac80211 monitor mode already enabled for [%s]%s on [%s]%s)\n" "${PHYDEV}" "${1}" "${PHYDEV}" "${i}"
 				exit


### PR DESCRIPTION
In many ways the same changes as those in PR #2559. 

line 500, remove explanatory comment
line 501, remove "shellcheck disable"
move line 502 > 500, change unquoted command substitution with `ls` command to a glob expression on the same directory path. line 503 > 500, Move the "type" directory name up one line. line 501, Add a test [ for the existence of such a directory ( "$i" ). line 503 > 501, Change the argument to the cat command. lines 502 & 503, Add two parameter expansions of "$i". Keep the total line count the same as is was.