### PR TITLE
airodump-ng.c: Add missing import on inttypes.h

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -63,6 +63,7 @@
 #include <getopt.h>
 #include <pthread.h>
 #include <limits.h>
+#include <inttypes.h>
 
 #include "aircrack-ng/pcre/compat-pcre.h"
 #include "aircrack-ng/defs.h"


### PR DESCRIPTION
 Otherwise the build fails with:
 ```
 src/airodump-ng/airodump-ng.c: In function ‘main’:
 src/airodump-ng/airodump-ng.c:6592:55: error: expected ‘)’ before ‘SCNd16’
  6592 |                                 if (sscanf(optarg, "%" SCNd16, &lopt.min_power) != 1)
       |                                           ~           ^~~~~~~
       |                                                       )
 src/airodump-ng/airodump-ng.c:86:1: note: ‘SCNd16’ is defined in header ‘<inttypes.h>’; did you forget to ‘#include <inttypes.h>’?
    85 | #include "radiotap/radiotap_iter.h"
   +++ |+#include <inttypes.h>
    86 |
```
    
Regresion introduced at https://github.com/aircrack-ng/aircrack-ng/commit/5fe67f2f6c9f19abbb25f657e1d3a7db981d84b4