### PR TITLE
Fix quitting aircrack-ng using CTRL+C

### DIFF
--- a/src/aircrack-ng/aircrack-ng.c
+++ b/src/aircrack-ng/aircrack-ng.c
@@ -637,15 +637,17 @@ static __attribute__((noinline)) void clean_exit(int ret)
 	close_aircrack = 1;
 	if (ret)
 	{
+		close_aircrack_fast = 1;
+
 		if (!opt.is_quiet)
 		{
 			printf("\nQuitting aircrack-ng...\n");
 			fflush(stdout);
 		}
-
-		close_aircrack_fast = 1;
-
-		return;
+		else
+		{
+			return;
+		}
 	}
 
 	if (opt.dict)


### PR DESCRIPTION
Fixes issue #2585

Allow for a user to quit while Aircrack prompts for a target.

Result:
<img width="623" alt="Screenshot of aircrack successfully closed using ctrl+c" src="https://github.com/aircrack-ng/aircrack-ng/assets/3667366/590ddbf4-38d3-44b1-bc09-e758647490fd">