### PR TITLE
build: add option to disable bsd library inclusion

### DIFF
--- a/build/m4/aircrack_ng_compat.m4
+++ b/build/m4/aircrack_ng_compat.m4
@@ -41,11 +41,12 @@ AC_DEFUN([AIRCRACK_NG_COMPAT], [
 AC_ARG_WITH(libbsd,
 	[AS_HELP_STRING([--with-libbsd[[=auto|yes|no]]], [use BSD library, [default=auto]])])
 
+AC_CHECK_FUNCS([strlcpy strlcat], [:])
+
 case $with_libbsd in
 	yes | "" | auto)
 		AC_CHECK_HEADERS([bsd/string.h], [HAVE_BSD_STRING_H=yes])
 		AC_CHECK_LIB([bsd], [strlcpy], [:])
-		AC_CHECK_FUNCS([strlcpy strlcat], [:])
 		;;
 esac
 

--- a/build/m4/aircrack_ng_compat.m4
+++ b/build/m4/aircrack_ng_compat.m4
@@ -38,11 +38,29 @@ dnl If you delete this exception statement from all source files in the
 dnl program, then also delete it here.
 
 AC_DEFUN([AIRCRACK_NG_COMPAT], [
+AC_ARG_WITH(libbsd,
+	[AS_HELP_STRING([--with-libbsd[[=auto|yes|no]]], [use BSD library, [default=auto]])])
 
-AC_CHECK_HEADERS([bsd/string.h], [HAVE_BSD_STRING_H=yes], [HAVE_BSD_STRING_H=no])
+case $with_libbsd in
+	yes | "" | auto)
+		AC_CHECK_HEADERS([bsd/string.h], [HAVE_BSD_STRING_H=yes])
+		AC_CHECK_LIB([bsd], [strlcpy], [:])
+		AC_CHECK_FUNCS([strlcpy strlcat], [:])
+		;;
+esac
+
 AM_CONDITIONAL([HAVE_BSD_STRING_H], [test "$HAVE_BSD_STRING_H" = yes])
-AC_CHECK_LIB([bsd], [strlcpy], [ LIBS="$LIBS -lbsd" ], [:])
-AC_CHECK_FUNCS([strlcpy strlcat], [:])
+
+if test $with_libbsd != no
+then
+	if test $ac_cv_lib_bsd_strlcpy = yes
+	then
+		LIBS="$LIBS -lbsd"
+	elif test $with_libbsd = yes
+	then
+		AC_MSG_ERROR([cannot configure required bsd library])
+	fi
+fi
 
 have_bsd=no
 if test "$cross_compiling" != yes


### PR DESCRIPTION
It might be needed to disable bsd inclusion and fallback to the compat functions even if bsd headers are detected.

This is the case when multiple library are cross-compiled and someone wants to explicitly compile aircrack-ng without linking to bsd library.

With the current implementation, if a bsd header is detected, the bsd library is always linked even if unwanted. Add option to configure this with the combo --with-libbsd=yes|no|auto with auto set by default.

Also add an extra featurw with introducing the possibility of requiring the bsd library and fail the configure phase.