### PR TITLE
Improve, simplify shell script

### DIFF
--- a/evalrev
+++ b/evalrev
@@ -2,17 +2,12 @@
 
 set -euf
 
-DIR=${1:-}
+DIR=${1:-'.'}
 CMD=${2:-}
 
-SCM=""
+SCM=
 
-if [ x$DIR = "x" ]
-then
-	DIR="."
-fi
-
-if test -d "${DIR}/.git"; then
+if [ -d "$DIR/.git" ]; then
     #
     # Locate the closest annotated tag
     #
@@ -28,40 +23,24 @@ if test -d "${DIR}/.git"; then
         REVISION="${REVISION}_rev-$(git rev-parse --verify --short HEAD)"
         SCM="_rev-$(git rev-parse --verify --short HEAD)"
     fi
-elif test -d "${DIR}/.svn"; then
-    REVISION="_r$(svnversion $DIR 2> /dev/null | sed 's/[^0-9]*//g')"
-    SCM="_r$(svnversion $DIR 2> /dev/null | sed 's/[^0-9]*//g')"
+elif [ -n "${GITHUB_SHA:-}" ]; then
+    SHORT_SHA_REVISION="$(echo "$GITHUB_SHA" | cut -b 1-8)"
 
-    if test x$REVISION = "x"; then
-        REVISION="_r$(svn info $DIR 2> /dev/null | grep -i revision | sed 's/[^0-9]*//g')"
-        SCM="_r$(svn info $DIR 2> /dev/null | grep -i revision | sed 's/[^0-9]*//g')"
-    fi
-
-    if test x$REVISION = "x"; then
-        if test -f "${DIR}/.svn/entries"; then
-            REVISION="_r$(cat ${DIR}/.svn/entries | grep -i revision | head -n 1 | sed 's/[^0-9]*//g')"
-            SCM="_r$(cat ${DIR}/.svn/entries | grep -i revision | head -n 1 | sed 's/[^0-9]*//g')"
-        fi
-    fi
-
-    if test x$REVISION = "x"; then
-        REVISION="_r1"
-        SCM="_r1"
-    fi
-elif [ -n "${GITHUB_SHA}" ]; then
-    SHORT_SHA_REVISION="$(echo ${GITHUB_SHA} | cut -b 1-8)"
-
-    VERSION=$(cat ${DIR}/AC_VERSION 2>/dev/null)
+    VERSION=$(cat "$DIR/AC_VERSION" 2>/dev/null)
     REVISION="${VERSION}_rev-${SHORT_SHA_REVISION}"
     SCM="_rev-${SHORT_SHA_REVISION}"
 else
-    REVISION="$(cat ${DIR}/AC_VERSION 2>/dev/null)"
+    REVISION="$(cat "$DIR/AC_VERSION" 2>/dev/null)"
 fi
 
-if test "x$CMD" = "xscm"; then
-    echo $SCM
-elif test "x$CMD" = "xquoted"; then
-    echo \"$REVISION\"
-else
-    echo $REVISION
-fi
+case $CMD in
+    'scm')
+        echo "$SCM"
+        ;;
+    'quoted')
+        echo \""$REVISION"\"
+        ;;
+    *)
+        echo "$REVISION"
+        ;;
+esac


### PR DESCRIPTION
- Fix unbound shell variable warning from `set -u` about `GITHUB_SHA` being unbound. Seen when running build locally.
- Remove obsolete SVN support
  - This section had a bug in it anyway -- `$REVISION` could never be empty since it starts out with `REVISION="_r$(...)"` - it would always start with `_r` regardless of what the subshell echoed, so yeah, never empty.
  - `svn.aircrack-ng.org`'s DNS record is also no longer up
- Fix various quoting issues reported by shellcheck.
- Avoid pedantic variable checking by just using defaults (`${VAR:-'default value'}`)
- Change else-if chain to `case`