### PR TITLE
use nproc in Dockerfile.*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ RUN set -x \
 		autoreconf -vif && \
 		set -e; \
 			./configure --with-experimental --with-ext-scripts --enable-maintainer-mode --prefix=/usr/local && \
-			make -j3 && \
+			make -j$(nproc) && \
 		set +e && \
-			if ! make check -j3; then \
+			if ! make check -j$(nproc); then \
 				echo "Processor: $(uname -m)"; \
 				for file in `grep -l "(exit status: [1-9]" test/*.log`; do \
 					echo "[*] Test ${file}:"; \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -27,8 +27,8 @@ RUN set -x \
 	autoreconf -vif && \
 	set -e; \
 		./configure --with-experimental --with-ext-scripts --enable-maintainer-mode --without-opt --prefix=/usr && \
-		make -j3 && \
-		make check -j3 && \
+		make -j$(nproc) && \
+		make check -j$(nproc) && \
 		make install DESTDIR=/output
 
 # Stage 2


### PR DESCRIPTION
Why are we hard coding -j3?  Test to the limit with -j$(nproc)

nproc is a coreutil which returns the number of available processors and
thus our build and test can scale to all cpus
