### PR TITLE
add a option to disable packet filter on aireplay-ng

### DIFF
--- a/include/aircrack-ng/support/communications.h
+++ b/include/aircrack-ng/support/communications.h
@@ -137,6 +137,7 @@ struct communication_options
 	int bittest;
 
 	int nodetect;
+	int no_filter;
 	int ignore_negative_one;
 	int rtc;
 

--- a/lib/libac/support/communications.c
+++ b/lib/libac/support/communications.c
@@ -704,7 +704,7 @@ int capture_ask_packet(int * caplen, int just_grab)
 
 		nb_pkt_read++;
 
-		if (filter_packet(h80211, *caplen) != 0) continue;
+		if (!opt.no_filter && filter_packet(h80211, *caplen) != 0) continue;
 
 		if (opt.fast) break;
 

--- a/src/aireplay-ng/aireplay-ng.c
+++ b/src/aireplay-ng/aireplay-ng.c
@@ -134,6 +134,7 @@ static const char usage[] =
 	"      -f fromds : frame control, From    DS bit\n"
 	"      -w iswep  : frame control, WEP     bit\n"
 	"      -D        : disable AP detection\n"
+	"      -N        : disable filter\n"
 	"\n"
 	"  Replay options:\n"
 	"\n"
@@ -6034,7 +6035,7 @@ int main(int argc, char * argv[])
 		int option = getopt_long(argc,
 								 argv,
 								 "b:d:s:m:n:u:v:t:Z:T:f:g:w:x:p:a:c:h:e:ji:r:k:"
-								 "l:y:o:q:Q0:1:23456789HFBDR",
+								 "l:y:o:q:Q0:1:23456789HFBDRN",
 								 long_options,
 								 &option_index);
 
@@ -6504,6 +6505,11 @@ int main(int argc, char * argv[])
 			case 'R':
 
 				opt.rtc = 0;
+				break;
+
+			case 'N':
+
+				opt.no_filter = 1;
 				break;
 
 			default:


### PR DESCRIPTION
it is useful when debugging packet that unable to pass filter, such as beacon.