### PR TITLE
Fix two memory corruption vulnerabilities 

### DIFF
--- a/src/airbase-ng/airbase-ng.c
+++ b/src/airbase-ng/airbase-ng.c
@@ -2480,6 +2480,11 @@ packet_recv(uint8_t * packet, size_t length, struct AP_conf * apc, int external)
 
 			st_cur->wep = (packet[z] & 0x10) >> 4;
 
+			// Reject packets with invalid sizes
+			if ((size_t)z + (size_t)fixed > length) {
+				return (1);
+			}
+
 			// Check SSID is present
 			tag = parse_tags(packet + z + fixed,
 							 IEEE80211_ELEMID_SSID,

--- a/src/ivstools/ivstools.c
+++ b/src/ivstools/ivstools.c
@@ -396,7 +396,7 @@ skip_station:
 			{
 				/* found a non-cloaked ESSID */
 
-				n = p[1];
+				n = (p[1] > 32) ? 32 : p[1];
 
 				memset(ap_cur->essid, 0, ESSID_LENGTH + 1);
 				memcpy(ap_cur->essid, p + 2, n);


### PR DESCRIPTION
This pull request addresses two security issues:

1. **Out-of-bounds read in `ivstools`** – could lead to a crash.
2. **Remote Denial of Service in `airbase-ng`** – may allow an attacker to crash the process remotely.

Both vulnerabilities have been disclosed to the maintainers via email with detailed technical information.