### PR TITLE
airmon-ng: workaround multiple phy indices in rfkill

### DIFF
--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -307,7 +307,7 @@ rfkill_check() {
 	fi
 	#first we have to find the rfkill index
 	#this is available as /sys/class/net/wlan0/phy80211/rfkill## but that's a bit difficult to parse
-	index="$(rfkill list | grep "${1}:" | awk -F: '{print $1}')"
+	index="$(rfkill list | grep "${1}:" | awk -F: '{print $1}' | head -n 1)"
 	if [ -z "$index" ]; then
 		return 187
 	fi


### PR DESCRIPTION
While moving wiphys in and out network namespaces, I noticed that rfkill can get confused and list the same phy multiple times.

$ rfkill list
6: phy5: Wireless LAN
        Soft blocked: no
        Hard blocked: no
7: phy5: Wireless LAN
        Soft blocked: no
        Hard blocked: no

This change attempts to use the first index instead of failing due to invalid parsing of the output.