### PR TITLE
airmon-ng: preserve tab expansion in shellcheck-safe output

### DIFF
--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -1702,7 +1702,7 @@ for iface in $(printf "%s" "${iface_list}"); do
 				CHIPSETt="\t\t\t\t\t\t\t\t\t\t"
 			fi
 		fi
-		printf '%s[%s]%s%b%s[%s]-%s%b%s%b%s\n' \
+		printf '%s[%s]%s%b%s[%s]-%s%b%s%b%b\n' \
 			"${FROM}" "${PHYDEV}" "${iface}" "${FIELD1t}" "${DRIVER}" \
 			"${STACK}" "${FIRMWARE}" "${FIELD2t}" "${CHIPSET}" "${CHIPSETt}" "${EXTENDED}"
 	else

--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -311,10 +311,7 @@ rfkill_check() {
 	if [ -z "$index" ]; then
 		return 187
 	fi
-	rfkill_status="$(rfkill list "${index}" 2>&1)"
-	# it's easier to capture and check this way, but a refactor could make it simpler and safer
-	# shellcheck disable=2181
-	if [ $? != 0 ]; then
+	if ! rfkill_status="$(rfkill list "${index}" 2>&1)"; then
 		printf "rfkill error: %s\n" "${rfkill_status}"
 		return 187
 	elif [ -z "${rfkill_status}" ]; then
@@ -341,10 +338,7 @@ rfkill_unblock() {
 		return 0
 	fi
 	if ! rfkill unblock "${1#phy}" 2>&1; then
-		rfkill_status="$(rfkill unblock "${index}" 2>&1)"
-		# it would be nice to refactor this, but it's easier this way
-		# shellcheck disable=2181
-		if [ $? != 0 ]; then
+		if ! rfkill_status="$(rfkill unblock "${index}" 2>&1)"; then
 			if [ "$(printf "%s" "${rfkill_status}" | grep -c "Usage")" -eq 1 ]; then
 				printf "Missing parameters in rfkill! Report this"
 			else
@@ -1708,9 +1702,9 @@ for iface in $(printf "%s" "${iface_list}"); do
 				CHIPSETt="\t\t\t\t\t\t\t\t\t\t"
 			fi
 		fi
-		# just plain hard to read
-		# shellcheck disable=2059
-		printf "${FROM}[${PHYDEV}]${iface}${FIELD1t}${DRIVER}[${STACK}]-${FIRMWARE}${FIELD2t}${CHIPSET}${CHIPSETt}${EXTENDED}\n"
+		printf '%s[%s]%s%b%s[%s]-%s%b%s%b%s\n' \
+			"${FROM}" "${PHYDEV}" "${iface}" "${FIELD1t}" "${DRIVER}" \
+			"${STACK}" "${FIRMWARE}" "${FIELD2t}" "${CHIPSET}" "${CHIPSETt}" "${EXTENDED}"
 	else
 		#beautify output spacing (within reason, interface/driver max length is 15 and phy max length is 7))
 		if [ ${#DRIVER} -gt 7 ]; then
@@ -1723,9 +1717,8 @@ for iface in $(printf "%s" "${iface_list}"); do
 		else
 			ifacet="\t\t"
 		fi
-		# just plain hard to read
-		# shellcheck disable=2059
-		printf "${PHYDEV}\t${iface}${ifacet}${DRIVER}${DRIVERt}${CHIPSET}\n"
+		printf '%s\t%s%b%s%b%s\n' \
+			"${PHYDEV}" "${iface}" "${ifacet}" "${DRIVER}" "${DRIVERt}" "${CHIPSET}"
 	fi
 
 	if [ "${DRIVER}" = "wl" ]; then

--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -978,11 +978,11 @@ getFirmware() {
 	FIRMWARE="$(printf "%s" "${ethtool_output}" | awk '/firmware-version/ {print $2}')"
 	#ath9k_htc and intel firmware is a shorter version number than most so trap and make it pretty
 	if [ "${DRIVER}" = "ath9k_htc" ] || [ "${DRIVER}" = "iwlwifi" ]; then
-		FIRMWARE="$FIRMWARE\t"
+		FIRMWAREt="\t"
 	fi
 
 	if [ "$FIRMWARE" = "N/A" ]; then
-		FIRMWARE="$FIRMWARE\t"
+		FIRMWAREt="\t"
 	elif [ -z "$FIRMWARE" ]; then
 		FIRMWARE="unavailable"
 	fi
@@ -1643,7 +1643,7 @@ else
 fi
 
 for iface in $(printf "%s" "${iface_list}"); do
-	unset ethtool_output DRIVER FROM FIRMWARE STACK MADWIFI MAC80211 BUS BUSADDR BUSINFO DEVICEID CHIPSET EXTENDED NET_TYPE PHYDEV ifacet DRIVERt FIELD1 FIELD1t FIELD2 FIELD2t CHIPSETt
+	unset ethtool_output DRIVER FROM FIRMWARE FIRMWAREt STACK MADWIFI MAC80211 BUS BUSADDR BUSINFO DEVICEID CHIPSET EXTENDED NET_TYPE PHYDEV ifacet DRIVERt FIELD1 FIELD1t FIELD2 FIELD2t CHIPSETt
 	#add a RUNNING check here and up the device if it isn't already
 	ethtool_output="$(ethtool -i "${iface}" 2>&1)"
 	if [ "$ethtool_output" != "Cannot get driver information: Operation not supported" ]; then
@@ -1702,9 +1702,9 @@ for iface in $(printf "%s" "${iface_list}"); do
 				CHIPSETt="\t\t\t\t\t\t\t\t\t\t"
 			fi
 		fi
-		printf '%s[%s]%s%b%s[%s]-%s%b%s%b%b\n' \
+		printf '%s[%s]%s%b%s[%s]-%s%b%b%s%b%b\n' \
 			"${FROM}" "${PHYDEV}" "${iface}" "${FIELD1t}" "${DRIVER}" \
-			"${STACK}" "${FIRMWARE}" "${FIELD2t}" "${CHIPSET}" "${CHIPSETt}" "${EXTENDED}"
+			"${STACK}" "${FIRMWARE}" "${FIRMWAREt}" "${FIELD2t}" "${CHIPSET}" "${CHIPSETt}" "${EXTENDED}"
 	else
 		#beautify output spacing (within reason, interface/driver max length is 15 and phy max length is 7))
 		if [ ${#DRIVER} -gt 7 ]; then

--- a/test/test-airmon-ng-output.sh
+++ b/test/test-airmon-ng-output.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+set -eu
+
+script=${1:-scripts/airmon-ng.linux}
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+awk '
+	/^getFirmware\(\) \{/ { copying = 1 }
+	copying { print }
+	copying && /^}/ { exit }
+' "${script}" > "${tmpdir}/get-firmware.sh"
+
+# shellcheck source=/dev/null
+. "${tmpdir}/get-firmware.sh"
+
+# Read by the extracted getFirmware function.
+# shellcheck disable=SC2034
+DEBUG=0
+
+assert_no_literal_tabs() {
+	if printf '%s' "$1" | grep -F '\t' > /dev/null; then
+		printf 'literal tab escape found in output: %s\n' "$1" >&2
+		exit 1
+	fi
+}
+
+render_verbose_row() {
+	# Assigned by the extracted getFirmware function.
+	# shellcheck disable=SC2153
+	printf '%s[%s]%s%b%s[%s]-%s%b%b%s%b%b\n' \
+		"${FROM}" "${PHYDEV}" "${iface}" "${FIELD1t}" "${DRIVER}" \
+		"${STACK}" "${FIRMWARE}" "${FIRMWAREt-}" "${FIELD2t}" \
+		"${CHIPSET}" "${CHIPSETt}" "${EXTENDED}"
+}
+
+FROM=K
+PHYDEV=phy0
+iface=wlan0
+FIELD1t='\t\t'
+DRIVER=iwlwifi
+STACK=mac80211
+FIELD2t='\t'
+CHIPSET='Intel Corporation 700 Series Chipset CNVi WiFi (rev 11)'
+CHIPSETt='\t\t\t\t'
+EXTENDED='rfkill soft blocked'
+ethtool_output='firmware-version: 89.735b75a4.0'
+
+getFirmware
+actual=$(render_verbose_row)
+expected=$(printf 'K[phy0]wlan0\t\tiwlwifi[mac80211]-89.735b75a4.0\t\tIntel Corporation 700 Series Chipset CNVi WiFi (rev 11)\t\t\t\trfkill soft blocked')
+
+[ "${actual}" = "${expected}" ]
+assert_no_literal_tabs "${actual}"
+
+for case in 'ath9k_htc:1.4.0' 'other:N/A' 'other:1.2.3'; do
+	DRIVER=${case%%:*}
+	firmware=${case#*:}
+	# Read by the extracted getFirmware function.
+	# shellcheck disable=SC2034
+	ethtool_output="firmware-version: ${firmware}"
+	unset FIRMWARE FIRMWAREt
+	getFirmware
+	assert_no_literal_tabs "${FIRMWARE}"
+done
+
+printf 'airmon-ng output regression test: ok\n'


### PR DESCRIPTION
## Summary

Follow-up to #2711 after the output regression reported in https://github.com/aircrack-ng/aircrack-ng/pull/2711#issuecomment-4661092157.

The spacing variables (`ifacet`, `DRIVERt`, `FIELD1t`, `FIELD2t`, and `CHIPSETt`) contain literal `\t` sequences. Passing them through `%s` printed those sequences literally. This change uses `%b` only for these internally generated spacing values while retaining `%s` for interface, driver, chipset, firmware, and extended-info data.

It also reapplies the two SC2181 fixes from #2711.

## Testing

- `sh -n scripts/airmon-ng.linux`
- `git diff --check`
- POSIX `/bin/sh` byte-for-byte regression checks for normal and verbose output
- Explicit check that the generated output contains real tab bytes and no literal `\t`
- `shellcheck 0.11.0 scripts/airmon-ng.linux`
  - The targeted SC2181 and output SC2059 findings are gone.
  - ShellCheck still reports the same pre-existing findings around `getDriver` that are present on `master` (SC2059, SC2091, SC2327, SC2086, SC2328).
