### PR TITLE
airodump-ng: align PWR values below -99

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -3751,7 +3751,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 	if (lopt.show_ap)
 	{
 		strbuf[0] = 0;
-		strlcat(strbuf, " BSSID              PWR ", sizeof(strbuf));
+		strlcat(strbuf, " BSSID               PWR ", sizeof(strbuf));
 
 		if (lopt.singlechan || lopt.singlefreq)
 			strlcat(strbuf, "RXQ ", sizeof(strbuf));
@@ -3901,7 +3901,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 			{
 				snprintf(strbuf + len,
 						 sizeof(strbuf) - len,
-						 "  %3d %3d %8lu %8lu %4d",
+						 "  %4d %3d %8lu %8lu %4d",
 						 ap_cur->avg_power,
 						 ap_cur->rx_quality,
 						 ap_cur->nb_bcn,
@@ -3912,7 +3912,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 			{
 				snprintf(strbuf + len,
 						 sizeof(strbuf) - len,
-						 "  %3d %8lu %8lu %4d",
+						 "  %4d %8lu %8lu %4d",
 						 ap_cur->avg_power,
 						 ap_cur->nb_bcn,
 						 ap_cur->nb_data,
@@ -4210,7 +4210,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 	{
 		strlcpy(strbuf,
 				" BSSID              STATION "
-				"           PWR    Rate    Lost   Frames  Notes  Probes",
+				"            PWR    Rate    Lost   Frames  Notes  Probes",
 				sizeof(strbuf));
 		strbuf[ws_col - 1] = '\0';
 		console_puts(strbuf);
@@ -4307,7 +4307,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 					   st_cur->stmac[4],
 					   st_cur->stmac[5]);
 
-				printf("  %3d ", st_cur->power);
+				printf("  %4d ", st_cur->power);
 				printf("  %2d", st_cur->rate_to / 1000000);
 				printf("%c", (st_cur->qos_fr_ds) ? 'e' : ' ');
 				printf("-%2d", st_cur->rate_from / 1000000);
@@ -4374,7 +4374,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 
 		strlcpy(strbuf,
 				" MAC       "
-				"          CH PWR    ACK ACK/s    CTS RTS_RX RTS_TX  OTHER",
+				"          CH  PWR    ACK ACK/s    CTS RTS_RX RTS_TX  OTHER",
 				sizeof(strbuf));
 		strbuf[ws_col - 1] = '\0';
 		console_puts(strbuf);
@@ -4408,7 +4408,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 				   na_cur->namac[5]);
 
 			printf("  %3d", na_cur->channel);
-			printf(" %3d", na_cur->power);
+			printf(" %4d", na_cur->power);
 			printf(" %6d", na_cur->ack);
 			printf("  %4d", na_cur->ackps);
 			printf(" %6d", na_cur->cts);

--- a/test/test-airodump-ng-power-column.sh
+++ b/test/test-airodump-ng-power-column.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -eu
+
+source_file=${1:-src/airodump-ng/airodump-ng.c}
+
+assert_source_contains() {
+	if ! grep -F "$1" "${source_file}" > /dev/null; then
+		printf 'missing expected power-column format: %s\n' "$1" >&2
+		exit 1
+	fi
+}
+
+assert_source_contains '"  %4d %3d %8lu %8lu %4d"'
+assert_source_contains '"  %4d %8lu %8lu %4d"'
+assert_source_contains 'printf("  %4d ", st_cur->power);'
+assert_source_contains 'printf(" %4d", na_cur->power);'
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+cat > "${tmpdir}/power-column.c" <<'EOF'
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+	const int powers[] = {9, -1, -99, -100, -127};
+	size_t i;
+
+	for (i = 0; i < sizeof(powers) / sizeof(powers[0]); i++)
+	{
+		char row[32];
+		char * separator;
+
+		snprintf(row, sizeof(row), "  %4d |NEXT", powers[i]);
+		separator = strchr(row, '|');
+		if (separator == NULL || separator - row != 7)
+		{
+			fprintf(stderr, "misaligned power row: %s\n", row);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+EOF
+
+"${CC:-cc}" -Wall -Wextra -Werror -o "${tmpdir}/power-column" \
+	"${tmpdir}/power-column.c"
+"${tmpdir}/power-column"
+
+printf 'airodump-ng power column regression test: ok\n'


### PR DESCRIPTION
## Summary

Fixes #2536.

`airodump-ng` formatted power values with `%3d`. Values such as `-100` and `-127` require four characters, so they shifted every column to their right.

This change:

- widens the PWR field from 3 to 4 characters
- updates AP, station, and ACK/unknown-station displays consistently
- adjusts the corresponding headers
- adds a regression test covering `9`, `-1`, `-99`, `-100`, and `-127`

## Before

```text
    9 | Beacons | #Data | CH
   -1 | Beacons | #Data | CH
  -99 | Beacons | #Data | CH
  -100 | Beacons | #Data | CH
  -127 | Beacons | #Data | CH
```

## After

```text
     9 | Beacons | #Data | CH
    -1 | Beacons | #Data | CH
   -99 | Beacons | #Data | CH
  -100 | Beacons | #Data | CH
  -127 | Beacons | #Data | CH
```

## Testing

The regression test rejects current `master` and passes with this change:

```text
missing expected power-column format: "  %4d %3d %8lu %8lu %4d"
origin/master rejected as expected (exit 1)
airodump-ng power column regression test: ok
```

Full build and test suite executed on Alpine Linux 3.20, x86_64, GCC 13.2.1, musl:

```text
$ AWK=awk ./configure --without-opt
$ make -j2
$ make check -j2

============================================================================
Testsuite summary for aircrack-ng 1.7.0
============================================================================
# TOTAL: 53
# PASS:  53
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

Additional checks:

```text
$ sh test/test-airodump-ng-power-column.sh
airodump-ng power column regression test: ok

$ shellcheck test/test-airodump-ng-power-column.sh
# no findings

$ git diff --check
# no findings
```
