### PR TITLE
airmon-ng: ignore iwconfig continuation lines

### DIFF
--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -1376,7 +1376,7 @@ listInterfaces() {
     done
   fi
   if [ "${WIRELESS_TOOLS}" = "1" ] && [ -x "$(command -v sort 2>&1)" ]; then
-    for iface in $(iwconfig 2> /dev/null | sed -e 's/^\(\w*\)\s.*/\1/' -e '/^$/d'); do
+    for iface in $(iwconfig 2> /dev/null | sed -n 's/^\([^[:space:]][^[:space:]]*\)[[:space:]].*/\1/p'); do
       iface_list="${iface_list} ${iface}"
     done
     #                                           sort needs newline separated,   convert back after

--- a/test/test-airmon-ng-iwconfig-interfaces.sh
+++ b/test/test-airmon-ng-iwconfig-interfaces.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -eu
+
+source_file=${1:-scripts/airmon-ng.linux}
+expected='wlan1
+phy1.mon
+wlan0'
+
+if ! grep -F "sed -n 's/^\([^[:space:]][^[:space:]]*\)[[:space:]].*/\1/p'" \
+	"${source_file}" > /dev/null; then
+	printf 'missing expected iwconfig interface parser\n' >&2
+	exit 1
+fi
+
+actual=$(
+	printf '%s\n' \
+		'wlan1     IEEE 802.11  ESSID:"test"' \
+		'phy1.mon  IEEE 802.11  Mode:Monitor  Tx-Power=3 dBm' \
+		'          Mode:Monitor  Frequency:2.437 GHz' \
+		'          Tx-Power=3 dBm' \
+		'wlan0     IEEE 802.11  ESSID:"other"' \
+		| sed -n 's/^\([^[:space:]][^[:space:]]*\)[[:space:]].*/\1/p'
+)
+
+if [ "${actual}" != "${expected}" ]; then
+	printf 'unexpected interface list:\n%s\n' "${actual}" >&2
+	exit 1
+fi
+
+printf 'airmon-ng iwconfig interface parsing: ok\n'


### PR DESCRIPTION
## Summary

Fixes #2357.

`listInterfaces()` parsed `iwconfig` output using GNU-style `\w` and `\s` expressions. Interface names containing punctuation, such as `phy1.mon`, were not reduced to their first field. The remaining line was then split into words, causing values such as `IEEE`, `802.11`, `Mode:Monitor`, and `dBm` to be treated as interface names.

This change uses POSIX character classes to:

- accept interface names such as `phy1.mon`
- extract only the first field from actual interface lines
- ignore indented `iwconfig` continuation lines

A regression test covers both dotted interface names and continuation lines.

## Reproduction on current master

Executed on Alpine Linux 3.20.3:

```text
wlan1
phy1.mon  IEEE 802.11  Mode:Monitor  Tx-Power=3 dBm
wlan0
```

The second line is subsequently split into invalid interface entries.

## After

```text
airmon-ng iwconfig interface parsing: ok
wlan1
phy1.mon
wlan0
```

## Testing

The regression test rejects unchanged `origin/master`:

```text
missing expected iwconfig interface parser
origin/master regression status: 1 (expected non-zero)
```

Targeted checks:

```text
$ sh test/test-airmon-ng-iwconfig-interfaces.sh
airmon-ng iwconfig interface parsing: ok

$ shellcheck test/test-airmon-ng-iwconfig-interfaces.sh
# no findings

$ sh -n scripts/airmon-ng.linux
# no findings

$ git diff --check
# no findings
```

Full build and test suite executed on Alpine Linux 3.20.3, x86_64, musl:

```text
============================================================================
Testsuite summary for aircrack-ng 1.7.0
============================================================================
# TOTAL: 53
# PASS:  53
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
