### PR TITLE
airodump-ng: add `--mfp` / `--pmf` to display Management Frame Protection AP/Client configuration

### DIFF
--- a/include/aircrack-ng/support/station.h
+++ b/include/aircrack-ng/support/station.h
@@ -179,6 +179,7 @@ struct AP_info
 
 	int marked;
 	int marked_color;
+	int mfp; /* -1 = unknown, 0 = not enabled, 1 = capable, 2 = required */
 	struct WPS_info wps;
 };
 
@@ -210,6 +211,7 @@ struct ST_info
 	int wpatype; /* 1=wpa1 2=wpa2             */
 	int wpahash; /* 1=md5(tkip) 2=sha1(ccmp)  */
 	int wep; /* capability encryption bit */
+	int mfp; /* -1 = unknown, 0 = not enabled, 1 = capable, 2 = required */
 
 	int qos_to_ds; /* does it use 802.11e to ds */
 	int qos_fr_ds; /* does it receive 802.11e   */

--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -2206,6 +2206,14 @@ skip_probe:
 				}
 			}
 		}
+
+		/* For open/WEP networks, MFP is necessarily disabled. */
+		if (ap_cur->mfp < 0
+			&& (ap_cur->security & (STD_OPN | STD_WEP))
+			&& !(ap_cur->security & (STD_WPA | STD_WPA2)))
+		{
+			ap_cur->mfp = 0;
+		}
 	}
 
 	/* packet parsing: Beacon & Probe response */
@@ -3816,7 +3824,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 			strlcat(strbuf, "        UPTIME ", sizeof(strbuf));
 
 		if (lopt.show_mfp)
-			strlcat(strbuf, "MFP ", sizeof(strbuf));
+			strlcat(strbuf, "MFP  ", sizeof(strbuf));
 
 		if (lopt.show_wps)
 		{
@@ -4109,15 +4117,15 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 
 			if (ws_col > (columns_ap - 4))
 			{
-				if (lopt.show_mfp)
-				{
-					int mfp_val = (ap_cur->mfp < 0) ? -1 : ap_cur->mfp;
-					snprintf(strbuf + len,
-							 sizeof(strbuf) - len,
-							 " %d ",
-							 mfp_val);
-					len = strlen(strbuf);
-				}
+			if (lopt.show_mfp)
+			{
+				int mfp_val = (ap_cur->mfp < 0) ? -1 : ap_cur->mfp;
+				snprintf(strbuf + len,
+						 sizeof(strbuf) - len,
+						 " %2d ",
+						 mfp_val);
+				len = strlen(strbuf);
+			}
 
 				if (lopt.show_wps)
 				{

--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -829,7 +829,7 @@ static const char usage[] =
 	"      --manufacturer        : Display manufacturer from IEEE OUI list\n"
 	"      --uptime              : Display AP Uptime from Beacon Timestamp\n"
 	"      --wps                 : Display WPS information (if any)\n"
-	"      --mfp, --fmt          : Display MFP information (-1/ blank unknown, 0 disabled, 1 capable, 2 required)\n"
+	"      --mfp, --pmf          : Display MFP information (-1/ blank unknown, 0 disabled, 1 capable, 2 required)\n"
 	"      --output-format\n"
 	"                  <formats> : Output format. Possible values:\n"
 	"                              pcap, ivs, csv, gps, kismet, netxml, "
@@ -6110,7 +6110,7 @@ int main(int argc, char * argv[])
 		   {"write-interval", 1, 0, 'I'},
 		   {"wps", 0, 0, 'W'},
 		   {"mfp", 0, 0, 'F'},
-		   {"fmt", 0, 0, 'F'},
+		   {"pmf", 0, 0, 'F'},
 		   {"background", 1, 0, 'K'},
 		   {"min-packets", 1, 0, 'n'},
 		   {"min-power", 1, 0, 'p'},

--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -2207,10 +2207,11 @@ skip_probe:
 			}
 		}
 
-		/* For open/WEP networks, MFP is necessarily disabled. */
+		/* MFP/802.11w only applies to RSN (WPA2/WPA3). For open, WEP
+		   and WPA1 networks it is necessarily disabled. */
 		if (ap_cur->mfp < 0
-			&& (ap_cur->security & (STD_OPN | STD_WEP))
-			&& !(ap_cur->security & (STD_WPA | STD_WPA2)))
+			&& (ap_cur->security & (STD_OPN | STD_WEP | STD_WPA))
+			&& !(ap_cur->security & STD_WPA2))
 		{
 			ap_cur->mfp = 0;
 		}
@@ -3824,7 +3825,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 			strlcat(strbuf, "        UPTIME ", sizeof(strbuf));
 
 		if (lopt.show_mfp)
-			strlcat(strbuf, "MFP  ", sizeof(strbuf));
+			strlcat(strbuf, "MFP ", sizeof(strbuf));
 
 		if (lopt.show_wps)
 		{
@@ -4399,7 +4400,7 @@ static void dump_print(int ws_row, int ws_col, int if_num)
 					if (st_cur->mfp < 0)
 						printf("    ");
 					else
-						printf("  %d", st_cur->mfp);
+						printf(" %3d", st_cur->mfp);
 				}
 				printf("  %-5s",
 					   (st_cur->wpa.pmkid[0] != 0)


### PR DESCRIPTION
This PR adds an optional column to the airodump-ng **live terminal display** showing the MFP / 802.11w (Protected Management Frames) state of each AP and station.

## What it does

- New flag `--mfp` (alias `--pmf`, since both names are common) enables an extra `MFP` column in both the AP and station tables.
- Reported value per network:
  - blank / `-1`: unknown (not yet seen)
  - `0`: disabled
  - `1`: capable
  - `2`: required
- Scope: display only. It only changes the on-screen table.
- The state is read from the RSN IE capabilities bits (bit 6 = required, bit 7 = capable) in beacons / probe responses for APs, and from the RSN IE in (re)association requests for stations.
- Open, WEP and WPA1 networks are reported as `0` (MFP only applies to RSN / WPA2-WPA3).
- A client's MFP value only appears once airodump captures that client's (re)association request, which carries the RSN IE.

## Changes

- Add `mfp` field to `struct AP_info` and `struct ST_info`, initialized to `-1`.
- Add `rsn_mfp_from_ie()` / `mfp_value_from_caps()` helpers to parse the RSN capabilities.
- Add the `--mfp`/`--pmf` long options, the `F` short option and the usage line.
- Render the new column in `dump_print()` and adjust column widths; minor table spacing / probes-width fixes.
- Wired the same way as the existing `--wps` flag (long/short option, optional column, per-AP/station rendering).
