### PR TITLE
airodump-ng: fix CSV Privacy field showing "WPA3 WPA2" for WPA3 networks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Version 1.8 (changes from aircrack-ng 1.7) - Released XX XXX 2023:
 * Aircrack-ng: Fix heap overflow in session handling, reported by Andrew Kramer (Commit hash 3301282)
 * Aircrack-ng: Handle Apple ARM CPUs model info
 * Airodump-ng: Fix bad optimization
+* Airodump-ng: Fix CSV Privacy field showing "WPA3 WPA2" for WPA3-SAE/OWE networks (Closes: #2679)
 * Airodump-ng: Display RXQ when using frequencies
 * Airodump-ng: Add support for multiple --bssid
 * Airodump-ng: When coloring BSSID, color newly added clients

--- a/src/airodump-ng/dump_write.c
+++ b/src/airodump-ng/dump_write.c
@@ -212,7 +212,8 @@ int dump_write_csv(struct AP_info * ap_1st,
 			{
 				if (ap_cur->security & AUTH_SAE || ap_cur->security & AUTH_OWE)
 					fprintf(opt.f_txt, " WPA3");
-				fprintf(opt.f_txt, " WPA2");
+				else
+					fprintf(opt.f_txt, " WPA2");
 			}
 			if (ap_cur->security & STD_WPA) fprintf(opt.f_txt, " WPA");
 			if (ap_cur->security & STD_WEP) fprintf(opt.f_txt, " WEP");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes #2679. In the old-style CSV output (`dump_write_csv`), the Privacy field
for a WPA3-SAE/OWE network is written as `WPA3 WPA2` instead of `WPA3`.

Root cause — in `src/airodump-ng/dump_write.c`, ` WPA2` is printed
unconditionally right after ` WPA3`:

```c
if (ap_cur->security & STD_WPA2) {
    if (ap_cur->security & AUTH_SAE || ap_cur->security & AUTH_OWE)
        fprintf(opt.f_txt, " WPA3");
    fprintf(opt.f_txt, " WPA2");   // always runs
}
```

A WPA3 network sets both `STD_WPA2` and `AUTH_SAE`/`AUTH_OWE`, so both tokens
are emitted. The interactive ENC column (`airodump-ng.c`) already guards the
`WPA2` branch with an `else` and prints a single `WPA3`; this change adds the
matching `else` so the CSV agrees for the WPA3 case.

Before / after (Privacy field) for an AP with `STD_WPA2 | AUTH_SAE | ENC_CCMP`:
- before: ` WPA3 WPA2`
- after:  ` WPA3`

WPA2 / WPA / WEP / OPN output is unchanged.

#### Is there anything you want to mention?

- Scope is limited to the reported WPA3-vs-WPA2 case. Two related, pre-existing
  quirks are intentionally left out to keep the change minimal: the following
  `if (ap_cur->security & STD_WPA)` (line ~217) is a separate `if` (not
  `else if` as in the TUI), so a WPA1/WPA2 transition-mode AP still prints
  `WPA2 WPA`; and the log CSV writer (`f_logcsv`, ~line 461) has no WPA3
  handling at all. Happy to address either in a follow-up if wanted.
- Verified the exact conditional in isolation (reproduces `WPA3 WPA2`, fixed to
  `WPA3`, no regression on WPA2/WPA/WEP/OPN) and confirmed the tree builds
  cleanly (`airodump-ng`). No end-to-end run included: airodump has no
  pcap-replay path for CSV output, and the hwsim integration tests skip under CI.

#### Is it ready for merging, or does it need work?

Ready for review.
