### PR TITLE
airmon-ng: find qcacld con_mode instead of assuming module name

### DIFF
--- a/scripts/airmon-ng.linux
+++ b/scripts/airmon-ng.linux
@@ -430,10 +430,27 @@ changeMac80211IfaceTypeMonitor() {
   printf "\t\t(monitor mode enabled)\n"
 }
 
+qcacldConModePath() {
+  # The qcacld module is not always called "wlan". On GKI-era devices it is
+  # built per-target, e.g. qca_cld3_adrastea, so locate con_mode instead of
+  # assuming the module name.
+  if [ -n "${QCACLD_CON_MODE}" ]; then
+    printf "%s" "${QCACLD_CON_MODE}"
+    return 0
+  fi
+  for f in /sys/module/*/parameters/con_mode; do
+    [ -f "${f}" ] || continue
+    QCACLD_CON_MODE="${f}"
+    printf "%s" "${QCACLD_CON_MODE}"
+    return 0
+  done
+  return 1
+}
+
 qcaldSafetyCheck() {
-  icnss_file="/sys/module/wlan/parameters/con_mode"
-  if [ ! -f "${icnss_file}" ]; then
-    printf "Unable to find %s which is needed to control mode.\n" "${icnss_file}"
+  icnss_file="$(qcacldConModePath)"
+  if [ -z "${icnss_file}" ] || [ ! -f "${icnss_file}" ]; then
+    printf "Unable to find a con_mode parameter under /sys/module/*/parameters/\n"
     printf "Is /sys mounted correctly?\n"
     exit 1
   fi
@@ -449,7 +466,7 @@ changeQcacldIfaceTypeMonitor() {
   #work if you have multiple cards with this driver
   #hopefully that never happens
   qcaldSafetyCheck
-  echo 4 > /sys/module/wlan/parameters/con_mode
+  echo 4 > "$(qcacldConModePath)"
   setLink "${1}" up
   printf "\t\t(monitor mode enabled)\n"
 }
@@ -510,7 +527,7 @@ startMac80211Iface() {
 		done
 	fi
   #handle Qualcomm qcacld
-  if [ "${DRIVER}" = "icnss" ]; then
+  if [ "${DRIVER}" = "icnss" ] || [ "${DRIVER#icnss}" != "${DRIVER}" ]; then
     setLink "${1}" down
     changeQcacldIfaceTypeMonitor "${1}"
     setChannelMac80211 "${1}"
@@ -743,7 +760,7 @@ changeQcacldIfaceTypeManaged() {
   setLink "${1}" down
   #stupidly unsafe with more than one card, oh well
   qcaldSafetyCheck
-  echo 0 > /sys/module/wlan/parameters/con_mode
+  echo 0 > "$(qcacldConModePath)"
   setLink "${1}" up
   printf "\t\t(monitor mode disabled)\n"
 }
@@ -759,7 +776,7 @@ stopMac80211Iface() {
 			printf "please report it.\n"
 			exit 1
 		else
-			if [ "${DRIVER}" = "icnss" ]; then
+			if [ "${DRIVER}" = "icnss" ] || [ "${DRIVER#icnss}" != "${DRIVER}" ]; then
 				changeQcacldIfaceTypeManaged "${1}"
 				return
 			fi


### PR DESCRIPTION
### Problem

The qcacld monitor mode support added in #2179 makes two assumptions that no longer hold on GKI-era devices:

1. `qcaldSafetyCheck()`, `changeQcacldIfaceTypeMonitor()` and `changeQcacldIfaceTypeManaged()` hardcode `/sys/module/wlan/parameters/con_mode`.
2. `startMac80211Iface()` and `stopMac80211Iface()` match `DRIVER = "icnss"` exactly.

Both are correct on the kernel 4.x devices that support was developed against, where qcacld builds as a generic `wlan.ko`. On GKI devices qcacld is built per target, so the module carries a target specific name and the interface reports a suffixed driver. On a Redmi Note 13 Pro 5G (SM7435, kernel 5.10 GKI, LineageOS 23.2):

```
$ ls /sys/module/*/parameters/con_mode
/sys/module/qca_cld3_adrastea/parameters/con_mode

$ awk -F= '$1=="DRIVER"{print $2}' /sys/class/net/wlan0/device/uevent
icnss2
```

So `qcaldSafetyCheck()` aborts with `Unable to find ... which is needed to control mode`, the qcacld branches are never taken, and monitor mode fails:

```
# airmon-ng start wlan0
ERROR adding monitor mode interface: command failed: Invalid argument (-22)
```

### Change

- Add `qcacldConModePath()`, which locates `con_mode` by globbing `/sys/module/*/parameters/con_mode` and caches the result in `QCACLD_CON_MODE`. Used by the safety check and by both mode writes.
- Match the `icnss` prefix instead of the exact string, so `icnss2` (and any future suffix) is handled.

This keeps the existing behaviour on devices where the module is `wlan` and the driver is `icnss`, and additionally covers the newer naming. It also removes the need to update the script again the next time a target specific module name appears.

The sequence itself is unchanged: `link down` -> `con_mode` -> `link up` -> set channel.

### Testing

On the device above, before the change:

```
# airmon-ng start wlan0
ERROR adding monitor mode interface: command failed: Invalid argument (-22)
# echo $?
1
```

After:

```
# airmon-ng start wlan0
                (monitor mode enabled)
# cat /sys/module/qca_cld3_adrastea/parameters/con_mode
4
# cat /sys/class/net/wlan0/type
803                                   # ARPHRD_IEEE80211_RADIOTAP
# iw dev
        Interface wlan0
                type monitor
```

Capture works (BSSIDs redacted):

```
# tcpdump -i wlan0 -c 5 -e -nn -Z root
... 1.0 Mb/s 2457 MHz 11b -74dBm signal -96dBm noise antenna 0 Beacon ... ESS CH: 10, PRIVACY
... 18.0 Mb/s 2457 MHz 11g -64dBm signal ... Unhandled Management subtype(7)
... 18.0 Mb/s 2457 MHz 11g -66dBm signal ... Authentication
5 packets captured
33 packets received by filter
0 packets dropped by kernel
```

And teardown:

```
# airmon-ng stop wlan0
                (monitor mode disabled)
# cat /sys/module/qca_cld3_adrastea/parameters/con_mode
0
# cat /sys/class/net/wlan0/type
1
```

Exactly one module exposes `con_mode` on this device, so the glob is unambiguous. I do not have a `wlan.ko` era device to hand, so a check on one of those would be welcome.

### Out of scope

This only fixes monitor mode enablement. `aireplay-ng` injection is a separate, driver side matter on this hardware: every wireless extensions ioctl returns `EOPNOTSUPP` (verified for `SIOCGIWMODE`, `SIOCSIWMODE`, `SIOCSIWFREQ`, `SIOCSIWRATE`), so `set_monitor()` in `lib/osdep/linux.c` cannot succeed regardless of this change. I have deliberately kept that out of this PR.
