### PR TITLE
airodump-ng, besside-ng: fix PCRE2 match data leak in ESSID filter

### DIFF
--- a/src/airodump-ng/airodump-ng.c
+++ b/src/airodump-ng/airodump-ng.c
@@ -938,9 +938,6 @@ int is_filtered_essid(const uint8_t * essid)
 	if (lopt.f_essid_regex)
 	{
 #ifdef HAVE_PCRE2
-		lopt.f_essid_match_data
-			= pcre2_match_data_create_from_pattern(lopt.f_essid_regex, NULL);
-
 		return COMPAT_PCRE_MATCH(lopt.f_essid_regex,
 								 essid,
 								 ESSID_LENGTH,
@@ -6571,6 +6568,21 @@ int main(int argc, char * argv[])
 #endif
 					exit(EXIT_FAILURE);
 				}
+
+#ifdef HAVE_PCRE2
+				/* Allocate match data once, here, rather than on every
+				 * is_filtered_essid() call - that leaked one match_data
+				 * per evaluated frame. */
+				lopt.f_essid_match_data
+					= pcre2_match_data_create_from_pattern(lopt.f_essid_regex,
+														   NULL);
+				if (lopt.f_essid_match_data == NULL)
+				{
+					printf("Error: could not allocate PCRE2 match data. "
+						   "Aborting\n");
+					exit(EXIT_FAILURE);
+				}
+#endif
 #else
 				printf("Error: Airodump-ng wasn't compiled with PCRE support; "
 					   "aborting\n");

--- a/src/besside-ng/besside-ng.c
+++ b/src/besside-ng/besside-ng.c
@@ -1126,9 +1126,6 @@ static int is_filtered_essid(char * essid)
 	if (_conf.cf_essid_regex)
 	{
 #ifdef HAVE_PCRE2
-		_conf.cf_essid_match_data
-			= pcre2_match_data_create_from_pattern(_conf.cf_essid_regex, NULL);
-
 		return COMPAT_PCRE_MATCH(_conf.cf_essid_regex,
 								 essid,
 								 MAX_IE_ELEMENT_SIZE,
@@ -3384,6 +3381,21 @@ int main(int argc, char * argv[])
 #endif
 					exit(EXIT_FAILURE);
 				}
+
+#ifdef HAVE_PCRE2
+				/* Allocate match data once, here, rather than on every
+				 * is_filtered_essid() call - that leaked one match_data
+				 * per evaluated frame. */
+				_conf.cf_essid_match_data
+					= pcre2_match_data_create_from_pattern(_conf.cf_essid_regex,
+														   NULL);
+				if (_conf.cf_essid_match_data == NULL)
+				{
+					printf("Error: could not allocate PCRE2 match data. "
+						   "Aborting\n");
+					exit(EXIT_FAILURE);
+				}
+#endif
 				break;
 #else
 				printf("Error: Regular expressions are unsupported in this "


### PR DESCRIPTION
## Summary

`is_filtered_essid()` allocates PCRE2 match data on **every call**, assigning to a single
struct field and overwriting the previous pointer. The function runs once per evaluated
frame, so this leaks one `pcre2_match_data` allocation per frame. The matching
`pcre2_match_data_free()` at cleanup only ever releases the last one.

Present in both `airodump-ng` and `besside-ng`.

```c
/* src/airodump-ng/airodump-ng.c, is_filtered_essid() */
#ifdef HAVE_PCRE2
    lopt.f_essid_match_data
        = pcre2_match_data_create_from_pattern(lopt.f_essid_regex, NULL);   // every frame

    return COMPAT_PCRE_MATCH(lopt.f_essid_regex, essid, ESSID_LENGTH,
                             lopt.f_essid_match_data) < 0;
#elif defined HAVE_PCRE
    return COMPAT_PCRE_MATCH(lopt.f_essid_regex, essid, ESSID_LENGTH, NULL) < 0;
#endif
```

The `HAVE_PCRE` branch passes `NULL` and allocates nothing, so it is unaffected. The leak
has been latent since PCRE2 support was added in 37bc38a1 (2023-01-20) and only surfaces
as distributions drop `libpcre3` and rebuild against PCRE2 — which is now most of them.

## Impact

Severe rather than gradual: the process is OOM-killed within seconds of a live capture,
making `--essid-regex` unusable on any PCRE2-linked build.

Reproduction needs no wireless hardware — replaying a capture is enough:

```bash
airodump-ng -r capture.cap -w /tmp/o                           # ~7 MB peak RSS
airodump-ng -r capture.cap --essid-regex somenet -w /tmp/o     # ~7.4 GB, OOM-killed
```

| Build | no `--essid-regex` | with `--essid-regex` |
|---|---|---|
| Current `master` | 7 MB | **7.4 GB**, killed |
| With this patch | 6.9 MB | **7.0 MB** |

Measured replaying a 1.1 MB capture on Kali (`libpcre2-8` 10.46), with `config.h`
reporting `#define HAVE_PCRE2 1`.

## Fix

Allocate the match data once, where the pattern is compiled in `case 'R':`, and reuse it.
The existing free at cleanup then correctly releases the single allocation. No change to
the `HAVE_PCRE` path.

`besside-ng` carries the same pattern in its own `is_filtered_essid()`, reached via
`should_attack()` from several packet-processing call sites, and is fixed identically.

## Verification

Filter behaviour is unchanged. Replaying a capture containing 8 distinct ESSIDs:

| Invocation | Result |
|---|---|
| no filter | all 8 ESSIDs present |
| regex matching one ESSID | only that ESSID, 11 APs retained |
| two-ESSID alternation | both matching ESSIDs, all others excluded |
| regex matching nothing | 0 APs retained |

A full `make` completes with no new errors or warnings in either file.
